### PR TITLE
Introduce versioning trait for model

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ class MyModel extends MondocAbstractModel
 }
 ```
 
+##### Optional traits...
+
+You can easily version data within a model by using the `\District5\Mondoc\Db\Model\Traits\MondocVersionedModelTrait`
+trait. This trait introduces a `_v` variable in the model, which you can choose to increment when you choose.
+
+**For example...**
+
+```php
+<?php
+class MyModel extends \District5\Mondoc\Db\Model\MondocAbstractModel
+{
+    use \District5\Mondoc\Db\Model\Traits\MondocVersionedModelTrait;
+    
+    // Rest of your model code...
+}
+```
+
 #### The service layer
 
 ```php

--- a/README.md
+++ b/README.md
@@ -262,17 +262,17 @@ $results = \District5Tests\MondocTests\Example\MyService::getPageByByObjectIdPag
 
 #### Useful information...
 
-To use a pre-determined ObjectId as the document `_id`, you can call `setPresetMongoId` against the model. For example:
+To use a pre-determined ObjectId as the document `_id`, you can call `setPresetObjectId` against the model. For example:
 
 ```php
 <?php
 $theId = new \MongoDB\BSON\ObjectId('61dfee5591efcf44e023d692');
 
 $person = new Person();
-$person->setPresetMongoId(new ObjectId());
+$person->setPresetObjectId(new ObjectId());
 $person->save();
 
-echo $person->getMongoIdString(); // 61dfee5591efcf44e023d692
+echo $person->getObjectIdString(); // 61dfee5591efcf44e023d692
 ```
 
 This will force the model to absorb this ObjectId and not generate a new one upon insertion.
@@ -300,10 +300,10 @@ $phpArrayFromArray = MondocTypes::arrayToPhp($bsonArray);
 
 // ObjectIds
 $anId = '61dfee5591efcf44e023d692';
-$mongoId = MondocTypes::toObjectId($anId);
+$objectId = MondocTypes::toObjectId($anId);
 // You can also pass existing ObjectId's into the conversion and nothing happens.
 // MondocTypes::toObjectId(new \MongoDB\BSON\ObjectId());
-// MondocTypes::toObjectId($mongoId);
+// MondocTypes::toObjectId($objectId);
 ```
 
 #### Query building

--- a/src/Mondoc/Db/Model/MondocAbstractModel.php
+++ b/src/Mondoc/Db/Model/MondocAbstractModel.php
@@ -111,7 +111,7 @@ class MondocAbstractModel extends MondocAbstractSubModel
      */
     final public function setMongoId(ObjectId $objectId)
     {
-        $this->_mondocMongoId = $objectId;
+        $this->_mondocObjectId = $objectId;
 
         return $this;
     }
@@ -169,13 +169,13 @@ class MondocAbstractModel extends MondocAbstractSubModel
      */
     public function delete(): bool
     {
-        if (false === $this->hasMongoId()) {
+        if (false === $this->hasObjectId()) {
             return false;
         }
 
         if (null !== $serviceFQCN = MondocConfig::getInstance()->getServiceForModel(get_called_class())) {
             /* @var $serviceFQCN MondocAbstractService (it's not, it's actually a string) */
-            return $serviceFQCN::delete($this->getMongoId());
+            return $serviceFQCN::delete($this->getObjectId());
         }
 
         if ($this->_mondocCollection === null) {
@@ -185,7 +185,7 @@ class MondocAbstractModel extends MondocAbstractSubModel
         try {
             $delete = $this->_mondocCollection->deleteOne(
                 [
-                    '_id' => $this->getMongoId()
+                    '_id' => $this->getObjectId()
                 ]
             );
 
@@ -255,7 +255,7 @@ class MondocAbstractModel extends MondocAbstractSubModel
      */
     protected function getFieldToFieldMap(): array
     {
-        $this->fieldToFieldMap['_id'] = '_mondocMongoId';
+        $this->fieldToFieldMap['_id'] = '_mondocObjectId';
 
         return $this->fieldToFieldMap;
     }
@@ -355,12 +355,12 @@ class MondocAbstractModel extends MondocAbstractSubModel
             return false;
         }
         /* @var $service MondocAbstractService */
-        if ($this->hasMongoId() === false) {
+        if ($this->hasObjectId() === false) {
             $this->{$field} += $delta;
             return false;
         }
 
-        if (true === $service::inc($this->getMongoId(), $field, $delta)) {
+        if (true === $service::inc($this->getObjectId(), $field, $delta)) {
             $this->{$field} += $delta;
             return true;
         }

--- a/src/Mondoc/Db/Model/MondocAbstractSubModel.php
+++ b/src/Mondoc/Db/Model/MondocAbstractSubModel.php
@@ -238,9 +238,9 @@ abstract class MondocAbstractSubModel
     protected function getPropertyExclusions(): array
     {
         return [
-            'mondocNested', 'fieldToFieldMap', '_mondocCollection',
-            '_mondocUnmapped', '_mondocDirty', '_mondocPresetMongoId', '_mondocMongoId', '_mondocBson',
-            '_mondocEstablishedSingleInternal', '_mondocEstablishedMultiInternal'
+            'mondocNested', 'fieldToFieldMap', '_mondocCollection', '_mondocUnmapped', '_mondocDirty',
+            '_mondocPresetMongoId', '_mondocObjectId', '_mondocBson', '_mondocEstablishedSingleInternal',
+            '_mondocEstablishedMultiInternal'
         ];
     }
 

--- a/src/Mondoc/Db/Model/Traits/MondocMongoIdTrait.php
+++ b/src/Mondoc/Db/Model/Traits/MondocMongoIdTrait.php
@@ -45,20 +45,29 @@ trait MondocMongoIdTrait
      *
      * @var null|ObjectId
      */
-    protected ?ObjectId $_mondocMongoId = null;
+    protected ?ObjectId $_mondocObjectId = null;
 
     /**
      * Get the string value for the ObjectId of the persisted model.
      *
      * @return null|string
      */
-    public function getMongoIdString(): ?string
+    public function getObjectIdString(): ?string
     {
-        if ($this->hasMongoId()) {
-            return $this->getMongoId()->__toString();
+        if ($this->hasObjectId()) {
+            return $this->getObjectId()->__toString();
         }
 
         return null;
+    }
+
+    /**
+     * @see MondocMongoIdTrait::getObjectIdString()
+     * @deprecated Use getObjectIdString() instead.
+     */
+    public function getMongoIdString(): ?string
+    {
+        return $this->getObjectIdString();
     }
 
     /**
@@ -66,9 +75,18 @@ trait MondocMongoIdTrait
      *
      * @return bool
      */
+    public function hasObjectId(): bool
+    {
+        return is_object($this->getObjectId()) && $this->getObjectId() instanceof ObjectId;
+    }
+
+    /**
+     * @see MondocMongoIdTrait::hasObjectId()
+     * @deprecated Use hasObjectId() instead.
+     */
     public function hasMongoId(): bool
     {
-        return is_object($this->getMongoId()) && $this->getMongoId() instanceof ObjectId;
+        return $this->hasObjectId();
     }
 
     /**
@@ -76,11 +94,20 @@ trait MondocMongoIdTrait
      *
      * @return null|ObjectId
      */
-    public function getMongoId(): ?ObjectId
+    public function getObjectId(): ?ObjectId
     {
         return MondocTypes::toObjectId(
-            $this->_mondocMongoId
+            $this->_mondocObjectId
         );
+    }
+
+    /**
+     * @see MondocMongoIdTrait::getObjectId()
+     * @deprecated Use getObjectId() instead.
+     */
+    public function getMongoId(): ?ObjectId
+    {
+        return $this->getObjectId();
     }
 
     /**
@@ -89,10 +116,20 @@ trait MondocMongoIdTrait
      * @return $this
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function unsetMongoId()
+    public function unsetObjectId()
     {
-        $this->_mondocMongoId = null;
+        $this->_mondocObjectId = null;
 
         return $this;
+    }
+
+    /**
+     * @see MondocMongoIdTrait::unsetObjectId()
+     * @deprecated Use unsetObjectId() instead.
+     * @noinspection PhpMissingReturnTypeInspection
+     */
+    public function unsetMongoId()
+    {
+        return $this->unsetObjectId();
     }
 }

--- a/src/Mondoc/Db/Model/Traits/MondocVersionedModelTrait.php
+++ b/src/Mondoc/Db/Model/Traits/MondocVersionedModelTrait.php
@@ -28,59 +28,83 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-namespace District5\Mondoc\Db\Service\Traits\Atomic;
-
-use MongoDB\BSON\ObjectId;
+namespace District5\Mondoc\Db\Model\Traits;
 
 /**
- * Trait DecrementTrait.
+ * Trait MondocVersionedModelTrait.
  *
- * @package District5\Mondoc\Db\Service\Traits\Atomic
+ * @package District5\Mondoc\Db\Model\Traits
  */
-trait DecrementTrait
+trait MondocVersionedModelTrait
 {
     /**
-     * Decrement a field by a given delta, using a whole number as the delta. IE passing `1` would DECREASE a
-     * number by 1.
+     * The version of the model. Defaults to 1.
      *
-     * @param ObjectId $id
-     * @param string $field
-     * @param int $delta
-     *
-     * @return bool
-     * @noinspection PhpUnused
+     * @var int
      */
-    public static function dec(ObjectId $id, string $field, int $delta = 1): bool
+    protected int $_v = 1;
+
+    /**
+     * Get the version of this model
+     *
+     * @return int
+     */
+    public function getModelVersion(): int
     {
-        return self::atomic(
-            $id,
-            ['$inc' => [$field => ($delta - ($delta * 2))]]
+        return $this->_v;
+    }
+
+    /**
+     * Is this model version $x?
+     *
+     * @param int $x
+     * @return bool
+     */
+    public function isModelVersionX(int $x): bool
+    {
+        return $this->_v === $x;
+    }
+
+    /**
+     * Set the version of this model
+     *
+     * @param int $version
+     *
+     * @return $this
+     * @noinspection PhpMissingReturnTypeInspection
+     */
+    public function setModelVersion(int $version)
+    {
+        $this->_v = $version;
+        if (method_exists($this, 'addDirty')) {
+            $this->addDirty('_v');
+        }
+        return $this;
+    }
+
+    /**
+     * Increment the version of this model
+     *
+     * @return $this
+     * @noinspection PhpMissingReturnTypeInspection
+     */
+    public function incrementModelVersion()
+    {
+        return $this->setModelVersion(
+            ($this->_v + 1)
         );
     }
 
     /**
-     * Decrement multiple fields by a given delta, using a whole number as the delta. IE passing `1` would DECREASE a
-     * number by 1.
+     * Decrement the version of this model
      *
-     * @param ObjectId $id
-     * @param array $fieldsToDeltas
-     * @return bool
-     * @noinspection PhpUnused
-     * @example
-     *      ->decMulti(
-     *          $model->getObjectId(),
-     *          ['age' => 1, 'logins' => 1]
-     *      )
-     *
+     * @return $this
+     * @noinspection PhpMissingReturnTypeInspection
      */
-    public static function decMulti(ObjectId $id, array $fieldsToDeltas): bool
+    public function decrementModelVersion()
     {
-        foreach ($fieldsToDeltas as $field => $delta) {
-            $fieldsToDeltas[$field] = ($delta - ($delta * 2));
-        }
-        return self::atomic(
-            $id,
-            ['$inc' => $fieldsToDeltas]
+        return $this->setModelVersion(
+            ($this->_v - 1)
         );
     }
 }

--- a/src/Mondoc/Db/Model/Traits/PresetMongoIdTrait.php
+++ b/src/Mondoc/Db/Model/Traits/PresetMongoIdTrait.php
@@ -55,7 +55,7 @@ trait PresetMongoIdTrait
      * @noinspection PhpMissingReturnTypeInspection
      * @noinspection PhpUnused
      */
-    public function setPresetMongoId(ObjectId|null $presetMongoId)
+    public function setPresetObjectId(ObjectId|null $presetMongoId)
     {
         $this->_mondocPresetMongoId = $presetMongoId;
 
@@ -63,13 +63,31 @@ trait PresetMongoIdTrait
     }
 
     /**
+     * @noinspection PhpMissingReturnTypeInspection
+     * @deprecated Use getPresetObjectId() instead.
+     */
+    public function setPresetMongoId(ObjectId|null $presetMongoId)
+    {
+        return $this->setPresetObjectId($presetMongoId);
+    }
+
+    /**
      * Does this model have a preset Mongo ID (which is used for setting the _id on insertion).
      *
      * @return bool
      */
+    public function hasPresetObjectId(): bool
+    {
+        return null !== $this->getPresetObjectId();
+    }
+
+    /**
+     * @noinspection PhpMissingReturnTypeInspection
+     * @deprecated Use hasPresetObjectId() instead.
+     */
     public function hasPresetMongoId(): bool
     {
-        return null !== $this->getPresetMongoId();
+        return $this->hasPresetObjectId();
     }
 
     /**
@@ -77,16 +95,33 @@ trait PresetMongoIdTrait
      *
      * @return null|ObjectId
      */
-    public function getPresetMongoId(): ?ObjectId
+    public function getPresetObjectId(): ?ObjectId
     {
         return $this->_mondocPresetMongoId;
     }
 
     /**
+     * @noinspection PhpMissingReturnTypeInspection
+     * @deprecated Use getPresetObjectId() instead.
+     */
+    public function getPresetMongoId(): ?ObjectId
+    {
+        return $this->getPresetObjectId();
+    }
+
+    /**
      * Remove the preset Mongo ID (which is used for setting the _id on insertion).
+     */
+    public function clearPresetObjectId(): void
+    {
+        $this->_mondocPresetMongoId = null;
+    }
+
+    /**
+     * @deprecated Use clearPresetObjectId() instead.
      */
     public function clearPresetMongoId(): void
     {
-        $this->_mondocPresetMongoId = null;
+        $this->clearPresetObjectId();
     }
 }

--- a/src/Mondoc/Db/Service/Traits/Atomic/IncrementTrait.php
+++ b/src/Mondoc/Db/Service/Traits/Atomic/IncrementTrait.php
@@ -64,7 +64,7 @@ trait IncrementTrait
      * @noinspection PhpUnused
      * @example
      *      ->incMulti(
-     *          $model->getMongoId(),
+     *          $model->getObjectId(),
      *          ['age' => 1, 'logins' => 1]
      *      )
      *

--- a/src/Mondoc/Db/Service/Traits/DeletionTrait.php
+++ b/src/Mondoc/Db/Service/Traits/DeletionTrait.php
@@ -58,9 +58,9 @@ trait DeletionTrait
         if (!is_object($model) || false === method_exists($model, 'isMondocModel')) {
             return false;
         }
-        if (self::delete($model->getMongoId())) {
+        if (self::delete($model->getObjectId())) {
             $model->setMongoCollection(null);
-            $model->unsetMongoId();
+            $model->unsetObjectId();
 
             return true;
         }

--- a/src/Mondoc/Db/Service/Traits/KeyOperationsTrait.php
+++ b/src/Mondoc/Db/Service/Traits/KeyOperationsTrait.php
@@ -58,7 +58,7 @@ trait KeyOperationsTrait
             get_called_class()
         );
         $result = $collection->updateOne(
-            ['_id' => $model->getMongoId()],
+            ['_id' => $model->getObjectId()],
             ['$unset' => [$key => 1]]
         );
 

--- a/src/Mondoc/Db/Service/Traits/Persistence/InsertMultiTrait.php
+++ b/src/Mondoc/Db/Service/Traits/Persistence/InsertMultiTrait.php
@@ -86,11 +86,11 @@ trait InsertMultiTrait
         $data = [];
         foreach ($modelsForThisService as $model) {
             $asArray = $model->asArray();
-            if (array_key_exists('_mondocMongoId', $asArray)) {
-                unset($asArray['_mondocMongoId']);
+            if (array_key_exists('_mondocObjectId', $asArray)) {
+                unset($asArray['_mondocObjectId']);
             }
-            if ($model->hasPresetMongoId()) {
-                $asArray['_id'] = $model->getPresetMongoId();
+            if ($model->hasPresetObjectId()) {
+                $asArray['_id'] = $model->getPresetObjectId();
             }
             $data[] = $asArray;
         }
@@ -108,7 +108,7 @@ trait InsertMultiTrait
                 foreach ($modelsForThisService as $v) {
                     if (array_key_exists($insertedKey, $ids)) {
                         $v->setMongoId($ids[$insertedKey]);
-                        $v->clearPresetMongoId();
+                        $v->clearPresetObjectId();
                         $v->setMongoCollection($collection);
                     }
                     $insertedKey++;

--- a/src/Mondoc/Db/Service/Traits/Persistence/InsertSingleTrait.php
+++ b/src/Mondoc/Db/Service/Traits/Persistence/InsertSingleTrait.php
@@ -56,17 +56,17 @@ trait InsertSingleTrait
             get_called_class()
         );
         $data = $model->asArray();
-        if (array_key_exists('_mondocMongoId', $data)) {
-            unset($data['_mondocMongoId']);
+        if (array_key_exists('_mondocObjectId', $data)) {
+            unset($data['_mondocObjectId']);
         }
-        if ($model->hasPresetMongoId()) {
-            $data['_id'] = $model->getPresetMongoId();
+        if ($model->hasPresetObjectId()) {
+            $data['_id'] = $model->getPresetObjectId();
         }
         $insert = $collection->insertOne(
             $data
         );
         if (1 === $insert->getInsertedCount()) {
-            $model->clearPresetMongoId();
+            $model->clearPresetObjectId();
             $model->setMongoId($insert->getInsertedId());
             $model->setMongoCollection($collection);
 

--- a/src/Mondoc/Db/Service/Traits/Persistence/UpdateTrait.php
+++ b/src/Mondoc/Db/Service/Traits/Persistence/UpdateTrait.php
@@ -77,8 +77,8 @@ trait UpdateTrait
                 }
             }
         }
-        if (array_key_exists('_mondocMongoId', $changeSet)) {
-            unset($changeSet['_mondocMongoId']);
+        if (array_key_exists('_mondocObjectId', $changeSet)) {
+            unset($changeSet['_mondocObjectId']);
         }
         $unsetValues = $model->getMondocKeysToRemove();
 
@@ -91,7 +91,7 @@ trait UpdateTrait
             $query['$unset'] = $unsetValues;
         }
         $performed = $collection->updateOne(
-            ['_id' => $model->getMongoId()],
+            ['_id' => $model->getObjectId()],
             $query
         );
         if ($performed->isAcknowledged()) {

--- a/src/Mondoc/Db/Service/Traits/PersistenceTrait.php
+++ b/src/Mondoc/Db/Service/Traits/PersistenceTrait.php
@@ -60,7 +60,7 @@ trait PersistenceTrait
         if (!is_object($model) || false === method_exists($model, 'isMondocModel')) {
             return false;
         }
-        if (null === $model->getMongoId()) {
+        if (null === $model->getObjectId()) {
             return self::insert($model);
         }
 

--- a/tests/MondocTests/BuilderTest.php
+++ b/tests/MondocTests/BuilderTest.php
@@ -56,9 +56,9 @@ class BuilderTest extends MondocBaseTest
         $m = new MyModel();
         $m->setName('Foo');
         $m->setAge(1);
-        $m->setPresetMongoId($objectId);
+        $m->setPresetObjectId($objectId);
         $this->assertTrue($m->save());
-        $this->assertEquals($objectId->__toString(), $m->getMongoIdString());
+        $this->assertEquals($objectId->__toString(), $m->getObjectIdString());
 
         $queryBuilderStringAndInt = new QueryBuilder();
         $equalsStringInt = new ValueEqualTo();
@@ -73,27 +73,27 @@ class BuilderTest extends MondocBaseTest
 
         $getModel = MyService::getOneByQueryBuilder($queryBuilderStringAndInt);
         /* @var $getModel MyModel */
-        $this->assertEquals($m->getMongoIdString(), $getModel->getMongoIdString());
+        $this->assertEquals($m->getObjectIdString(), $getModel->getObjectIdString());
         $this->assertEquals('Foo', $getModel->getName());
         $this->assertEquals(1, $getModel->getAge());
 
         $getModel = MyService::getOneByQueryBuilder($queryBuilderObjectId);
         /* @var $getModel MyModel */
-        $this->assertEquals($m->getMongoIdString(), $getModel->getMongoIdString());
+        $this->assertEquals($m->getObjectIdString(), $getModel->getObjectIdString());
         $this->assertEquals('Foo', $getModel->getName());
         $this->assertEquals(1, $getModel->getAge());
 
         $getModels = MyService::getMultiByQueryBuilder($queryBuilderStringAndInt);
         /* @var $getModels MyModel[] */
         $this->assertCount(1, $getModels);
-        $this->assertEquals($m->getMongoIdString(), $getModels[0]->getMongoIdString());
+        $this->assertEquals($m->getObjectIdString(), $getModels[0]->getObjectIdString());
         $this->assertEquals('Foo', $getModels[0]->getName());
         $this->assertEquals(1, $getModels[0]->getAge());
 
         $getModels = MyService::getMultiByQueryBuilder($queryBuilderObjectId);
         /* @var $getModels MyModel[] */
         $this->assertCount(1, $getModels);
-        $this->assertEquals($m->getMongoIdString(), $getModels[0]->getMongoIdString());
+        $this->assertEquals($m->getObjectIdString(), $getModels[0]->getObjectIdString());
         $this->assertEquals('Foo', $getModels[0]->getName());
         $this->assertEquals(1, $getModels[0]->getAge());
     }

--- a/tests/MondocTests/Example/VersionedModel.php
+++ b/tests/MondocTests/Example/VersionedModel.php
@@ -28,60 +28,43 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-namespace District5\Mondoc\Db\Model\Traits;
+namespace District5Tests\MondocTests\Example;
+
+use DateTime;
+use District5\Mondoc\Db\Model\MondocAbstractModel;
+use District5\Mondoc\Db\Model\Traits\MondocVersionedModelTrait;
+use MongoDB\BSON\UTCDateTime;
 
 /**
- * Trait DirtyAttributesTrait.
+ * Class VersionedModel.
  *
- * @package District5\Mondoc\Db\Model\Traits
+ * @package MyNs\Model
  */
-trait DirtyAttributesTrait
+class VersionedModel extends MondocAbstractModel
 {
-    /**
-     * Holds any dirty values. As called with `$this->addDirty('foo');`
-     * Dirty values aren't referenced for new objects. New documents
-     * are established by the presence of an `_id` field. Which results
-     * in a full insertion.
-     *
-     * @var array
-     */
-    protected array $_mondocDirty = [];
+    use MondocVersionedModelTrait;
 
     /**
-     * Clear the dirty parameter array. Dirty values aren't referenced for new objects.
-     *
+     * @var string|null
+     */
+    protected string|null $name = null;
+
+    /**
+     * @param string $name
      * @return $this
-     * @noinspection PhpMissingReturnTypeInspection
      */
-    public function clearDirty()
+    public function setName(string $name): self
     {
-        $this->_mondocDirty = [];
-
+        $this->name = $name;
+        $this->addDirty('name');
         return $this;
     }
 
     /**
-     * Get the array of dirty values (values that need to be updated). Dirty values aren't referenced for new objects.
-     *
-     * @return array
+     * @return string|null
      */
-    public function getDirty(): array
+    public function getName(): ?string
     {
-        return $this->_mondocDirty;
-    }
-
-    /**
-     * Add a dirty value, indicating it should be saved upon updating. Dirty values aren't referenced for new objects.
-     *
-     * @param string $key
-     *
-     * @return $this
-     * @noinspection PhpMissingReturnTypeInspection
-     */
-    protected function addDirty(string $key)
-    {
-        $this->_mondocDirty[] = $key;
-
-        return $this;
+        return $this->name;
     }
 }

--- a/tests/MondocTests/Example/VersionedService.php
+++ b/tests/MondocTests/Example/VersionedService.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests\Example;
+
+use District5\Mondoc\Db\Service\MondocAbstractService;
+
+/**
+ * Class VersionedService.
+ *
+ * @package District5Tests\MondocTests\Service
+ */
+class VersionedService extends MondocAbstractService
+{
+    /**
+     * @return string
+     */
+    protected static function getCollectionName(): string
+    {
+        return 'versioned_model';
+    }
+}

--- a/tests/MondocTests/ModelFunctionalityTest.php
+++ b/tests/MondocTests/ModelFunctionalityTest.php
@@ -81,7 +81,7 @@ class ModelFunctionalityTest extends MondocBaseTest
         $inflated = MyModel::inflateSingleArray($data);
         $this->assertEquals('Foo', $inflated->getName());
         $this->assertEquals(2, $inflated->getAge());
-        $this->assertEquals($anId->__toString(), $inflated->getMongoIdString());
+        $this->assertEquals($anId->__toString(), $inflated->getObjectIdString());
     }
 
     public function testDateMethods()
@@ -95,12 +95,12 @@ class ModelFunctionalityTest extends MondocBaseTest
         /** @noinspection PhpRedundantOptionalArgumentInspection */
         $this->assertEquals($nowDate->format('Y-m-d H:i:s'), $m->getDate(false)->format('Y-m-d H:i:s'));
         $this->assertEquals($nowDate->format('Y-m-d H:i:s'), $m->getDate(true)->toDateTime()->format('Y-m-d H:i:s'));
-        $this->assertFalse($m->hasMongoId());
+        $this->assertFalse($m->hasObjectId());
         $m->save();
-        $this->assertTrue($m->hasMongoId());
-        $found = DateService::getById($m->getMongoId());
+        $this->assertTrue($m->hasObjectId());
+        $found = DateService::getById($m->getObjectId());
         /* @var $found DateModel */
-        $this->assertEquals($m->getMongoIdString(), $found->getMongoIdString());
+        $this->assertEquals($m->getObjectIdString(), $found->getObjectIdString());
         /** @noinspection PhpRedundantOptionalArgumentInspection */
         $this->assertEquals($m->getDate(false)->format('Y-m-d H:i:s'), $found->getDate(false)->format('Y-m-d H:i:s'));
         $this->assertTrue($found->delete());
@@ -149,17 +149,17 @@ class ModelFunctionalityTest extends MondocBaseTest
         $mT->setAge(2);
         $mT->setName(uniqid());
 
-        $this->assertFalse($m->hasMongoId());
-        $this->assertFalse($mT->hasMongoId());
-        $this->assertFalse($m->hasPresetMongoId());
-        $this->assertFalse($mT->hasPresetMongoId());
+        $this->assertFalse($m->hasObjectId());
+        $this->assertFalse($mT->hasObjectId());
+        $this->assertFalse($m->hasPresetObjectId());
+        $this->assertFalse($mT->hasPresetObjectId());
 
         $this->assertTrue(MyService::insertMulti([$m, $mT]));
 
-        $this->assertTrue($m->hasMongoId());
-        $this->assertTrue($mT->hasMongoId());
-        $this->assertFalse($m->hasPresetMongoId());
-        $this->assertFalse($mT->hasPresetMongoId());
+        $this->assertTrue($m->hasObjectId());
+        $this->assertTrue($mT->hasObjectId());
+        $this->assertFalse($m->hasPresetObjectId());
+        $this->assertFalse($mT->hasPresetObjectId());
 
         $this->assertTrue($m->delete());
         $this->assertTrue($mT->delete());
@@ -202,20 +202,20 @@ class ModelFunctionalityTest extends MondocBaseTest
         $mT = new DateModel();
         $mT->setDate(DateTime::createFromFormat('Y-m-d H:i:s', '2016-01-01 00:00:00'));
 
-        $this->assertFalse($m->hasMongoId());
-        $this->assertFalse($mT->hasMongoId());
-        $this->assertFalse($m->hasPresetMongoId());
-        $this->assertFalse($mT->hasPresetMongoId());
+        $this->assertFalse($m->hasObjectId());
+        $this->assertFalse($mT->hasObjectId());
+        $this->assertFalse($m->hasPresetObjectId());
+        $this->assertFalse($mT->hasPresetObjectId());
 
         $this->assertTrue(MyService::insertMulti([$m, $mT]));
 
-        $this->assertTrue($m->hasMongoId());
-        $this->assertTrue($mT->hasMongoId());
-        $this->assertFalse($m->hasPresetMongoId());
-        $this->assertFalse($mT->hasPresetMongoId());
+        $this->assertTrue($m->hasObjectId());
+        $this->assertTrue($mT->hasObjectId());
+        $this->assertFalse($m->hasPresetObjectId());
+        $this->assertFalse($mT->hasPresetObjectId());
 
-        $this->assertEquals($m->getMongoIdString(), MyService::getOneByCriteria([])->getMongoIdString());
-        $this->assertEquals($mT->getMongoIdString(), DateService::getOneByCriteria([])->getMongoIdString());
+        $this->assertEquals($m->getObjectIdString(), MyService::getOneByCriteria([])->getObjectIdString());
+        $this->assertEquals($mT->getObjectIdString(), DateService::getOneByCriteria([])->getObjectIdString());
 
         $this->assertTrue($m->delete());
         $this->assertTrue($mT->delete());
@@ -229,13 +229,13 @@ class ModelFunctionalityTest extends MondocBaseTest
         $m->setAge(1);
         $m->setName(uniqid());
 
-        $this->assertFalse($m->hasMongoId());
-        $this->assertFalse($m->hasPresetMongoId());
+        $this->assertFalse($m->hasObjectId());
+        $this->assertFalse($m->hasPresetObjectId());
 
         $this->assertTrue(MyService::insertMulti([$m]));
 
-        $this->assertTrue($m->hasMongoId());
-        $this->assertFalse($m->hasPresetMongoId());
+        $this->assertTrue($m->hasObjectId());
+        $this->assertFalse($m->hasPresetObjectId());
 
         $this->assertTrue($m->delete());
     }
@@ -250,27 +250,27 @@ class ModelFunctionalityTest extends MondocBaseTest
         $m = new MyModel();
         $m->setAge(1);
         $m->setName(uniqid());
-        $m->setPresetMongoId($idOne);
+        $m->setPresetObjectId($idOne);
 
         $mT = new MyModel();
         $mT->setAge(2);
         $mT->setName(uniqid());
-        $mT->setPresetMongoId($idTwo);
+        $mT->setPresetObjectId($idTwo);
 
-        $this->assertFalse($m->hasMongoId());
-        $this->assertFalse($mT->hasMongoId());
-        $this->assertTrue($m->hasPresetMongoId());
-        $this->assertTrue($mT->hasPresetMongoId());
+        $this->assertFalse($m->hasObjectId());
+        $this->assertFalse($mT->hasObjectId());
+        $this->assertTrue($m->hasPresetObjectId());
+        $this->assertTrue($mT->hasPresetObjectId());
 
         $this->assertTrue(MyService::insertMulti([$m, $mT]));
 
-        $this->assertEquals($idOne->__toString(), $m->getMongoIdString());
-        $this->assertEquals($idTwo->__toString(), $mT->getMongoIdString());
+        $this->assertEquals($idOne->__toString(), $m->getObjectIdString());
+        $this->assertEquals($idTwo->__toString(), $mT->getObjectIdString());
 
-        $this->assertTrue($m->hasMongoId());
-        $this->assertTrue($mT->hasMongoId());
-        $this->assertFalse($m->hasPresetMongoId());
-        $this->assertFalse($mT->hasPresetMongoId());
+        $this->assertTrue($m->hasObjectId());
+        $this->assertTrue($mT->hasObjectId());
+        $this->assertFalse($m->hasPresetObjectId());
+        $this->assertFalse($mT->hasPresetObjectId());
 
         $this->assertTrue($m->delete());
         $this->assertTrue($mT->delete());
@@ -285,17 +285,17 @@ class ModelFunctionalityTest extends MondocBaseTest
         $m = new MyModel();
         $m->setAge(1);
         $m->setName(uniqid());
-        $m->setPresetMongoId($idOne);
+        $m->setPresetObjectId($idOne);
 
-        $this->assertFalse($m->hasMongoId());
-        $this->assertTrue($m->hasPresetMongoId());
+        $this->assertFalse($m->hasObjectId());
+        $this->assertTrue($m->hasPresetObjectId());
 
         $this->assertTrue(MyService::insertMulti([$m]));
 
-        $this->assertEquals($idOne->__toString(), $m->getMongoIdString());
+        $this->assertEquals($idOne->__toString(), $m->getObjectIdString());
 
-        $this->assertTrue($m->hasMongoId());
-        $this->assertFalse($m->hasPresetMongoId());
+        $this->assertTrue($m->hasObjectId());
+        $this->assertFalse($m->hasPresetObjectId());
 
         $this->assertTrue($m->delete());
     }
@@ -309,13 +309,13 @@ class ModelFunctionalityTest extends MondocBaseTest
         $m->setName($this->getUniqueKey());
 
         // not been saved yet
-        $this->assertFalse($m->hasMongoId());
+        $this->assertFalse($m->hasObjectId());
 
         // save the model
         $this->assertTrue($m->save());
 
         // ensure it has a mongo id now
-        $this->assertTrue($m->hasMongoId());
+        $this->assertTrue($m->hasObjectId());
 
         // delete the model
         $this->assertTrue($m->delete());
@@ -332,7 +332,7 @@ class ModelFunctionalityTest extends MondocBaseTest
         $this->assertCount(1, MyService::getMultiWhereKeyEqualsValue('age', 2));
         $this->assertCount(0, MyService::getMultiWhereKeyDoesNotEqualValue('age', 2));
 
-        $this->assertEquals($m->getMongoIdString(), MyService::getOneWhereKeyEqualsValue('age', 2)->getMongoIdString());
+        $this->assertEquals($m->getObjectIdString(), MyService::getOneWhereKeyEqualsValue('age', 2)->getObjectIdString());
         $this->assertNull(MyService::getOneWhereKeyDoesNotEqualValue('age', 2));
 
         // delete the model
@@ -379,16 +379,16 @@ class ModelFunctionalityTest extends MondocBaseTest
         $m->setName($this->getUniqueKey());
         $m->save();
 
-        $this->assertEquals(90, MyService::getById($m->getMongoId())->getAge());
+        $this->assertEquals(90, MyService::getById($m->getObjectId())->getAge());
 
         $this->assertTrue($m->incrementAge());
         $this->assertEquals(91, $m->getAge());
-        $this->assertEquals(91, MyService::getById($m->getMongoId())->getAge());
+        $this->assertEquals(91, MyService::getById($m->getObjectId())->getAge());
 
         $this->assertTrue($m->decrementAge());
         $this->assertTrue($m->decrementAge());
         $this->assertEquals(89, $m->getAge());
-        $this->assertEquals(89, MyService::getById($m->getMongoId())->getAge());
+        $this->assertEquals(89, MyService::getById($m->getObjectId())->getAge());
 
         // delete the model
         $this->assertTrue($m->delete());
@@ -403,10 +403,10 @@ class ModelFunctionalityTest extends MondocBaseTest
         $m->setName($this->getUniqueKey());
         $m->save();
 
-        MyService::decMulti($m->getMongoId(), ['age' => 2]);
-        $this->assertEquals(99, MyService::getById($m->getMongoId())->getAge());
-        MyService::incMulti($m->getMongoId(), ['age' => 4]);
-        $this->assertEquals(103, MyService::getById($m->getMongoId())->getAge());
+        MyService::decMulti($m->getObjectId(), ['age' => 2]);
+        $this->assertEquals(99, MyService::getById($m->getObjectId())->getAge());
+        MyService::incMulti($m->getObjectId(), ['age' => 4]);
+        $this->assertEquals(103, MyService::getById($m->getObjectId())->getAge());
 
         // delete the model
         $this->assertTrue($m->delete());
@@ -431,42 +431,42 @@ class ModelFunctionalityTest extends MondocBaseTest
         $this->assertEquals(2, MyService::aggregate()->getAverage('age'));
         $this->assertEquals(2, MyService::aggregate()->getSum('age'));
 
-        $this->assertTrue(MyService::inc($m->getMongoId(), 'age', 2));
-        $this->assertEquals(4, MyService::getById($m->getMongoId())->getAge());
+        $this->assertTrue(MyService::inc($m->getObjectId(), 'age', 2));
+        $this->assertEquals(4, MyService::getById($m->getObjectId())->getAge());
         $this->assertEquals(4, MyService::aggregate()->getAverage('age'));
         $this->assertEquals(4, MyService::aggregate()->getSum('age'));
 
-        $this->assertTrue(MyService::updateOne(['_id' => $m->getMongoId()], ['$set' => ['age' => 2]]));
-        $this->assertEquals(2, MyService::getById($m->getMongoId())->getAge());
+        $this->assertTrue(MyService::updateOne(['_id' => $m->getObjectId()], ['$set' => ['age' => 2]]));
+        $this->assertEquals(2, MyService::getById($m->getObjectId())->getAge());
         $this->assertEquals(2, MyService::aggregate()->getAverage('age'));
         $this->assertEquals(2, MyService::aggregate()->getSum('age'));
 
-        $this->assertTrue(MyService::updateOne(['_id' => $m->getMongoId()], ['$set' => ['age' => 4]]));
-        $this->assertEquals(4, MyService::getById($m->getMongoId())->getAge());
+        $this->assertTrue(MyService::updateOne(['_id' => $m->getObjectId()], ['$set' => ['age' => 4]]));
+        $this->assertEquals(4, MyService::getById($m->getObjectId())->getAge());
         $this->assertEquals(4, MyService::aggregate()->getAverage('age'));
         $this->assertEquals(4, MyService::aggregate()->getSum('age'));
 
-        $this->assertTrue(MyService::dec($m->getMongoId(), 'age', 2));
-        $this->assertEquals(2, MyService::getById($m->getMongoId())->getAge());
+        $this->assertTrue(MyService::dec($m->getObjectId(), 'age', 2));
+        $this->assertEquals(2, MyService::getById($m->getObjectId())->getAge());
         $this->assertEquals(2, MyService::aggregate()->getAverage('age'));
         $this->assertEquals(2, MyService::aggregate()->getAverage('age', ['name' => $m->getName()]));
         $this->assertEquals(2, MyService::aggregate()->getSum('age'));
 
         $this->assertTrue(MyService::updateMany(['age' => 2], ['$set' => ['age' => 123]]));
-        $this->assertEquals(123, MyService::getById($m->getMongoId())->getAge());
+        $this->assertEquals(123, MyService::getById($m->getObjectId())->getAge());
 
         $queryBuilder = MyService::getQueryBuilder();
         $queryBuilder->addQueryPart(ValueEqualTo::get()->integer('age', 123));
         $this->assertTrue(MyService::updateManyByQueryBuilder($queryBuilder, ['$set' => ['age' => 456]]));
-        $this->assertEquals(456, MyService::getById($m->getMongoId())->getAge());
+        $this->assertEquals(456, MyService::getById($m->getObjectId())->getAge());
 
         $queryBuilderTwo = MyService::getQueryBuilder();
         $queryBuilderTwo->addQueryPart(ValueEqualTo::get()->integer('age', 456));
         $this->assertTrue(MyService::updateOneByQueryBuilder($queryBuilderTwo, ['$set' => ['age' => 789]]));
-        $this->assertEquals(789, MyService::getById($m->getMongoId())->getAge());
+        $this->assertEquals(789, MyService::getById($m->getObjectId())->getAge());
 
         // Get the ID
-        $theId = $m->getMongoIdString();
+        $theId = $m->getObjectIdString();
 
         unset($m);
 
@@ -485,8 +485,8 @@ class ModelFunctionalityTest extends MondocBaseTest
         $this->assertEquals($name, $find->getName());
 
         // ensure it has a mongo id now
-        $this->assertTrue($find->hasMongoId());
-        $this->assertEquals($theId, $find->getMongoIdString());
+        $this->assertTrue($find->hasObjectId());
+        $this->assertEquals($theId, $find->getObjectIdString());
 
         unset($find);
 
@@ -504,8 +504,8 @@ class ModelFunctionalityTest extends MondocBaseTest
         $this->assertInstanceOf(MyModel::class, $multiByIds[0]);
 
         // ensure it has a mongo id now
-        $this->assertTrue($multi[0]->hasMongoId());
-        $this->assertEquals($theId, $multi[0]->getMongoIdString());
+        $this->assertTrue($multi[0]->hasObjectId());
+        $this->assertEquals($theId, $multi[0]->getObjectIdString());
 
         unset($multi);
 
@@ -582,21 +582,21 @@ class ModelFunctionalityTest extends MondocBaseTest
         $ids = [];
         $results = MyService::getPage($paginator, [], 'name', 1);
         $this->assertCount(1, $results);
-        $this->assertFalse(in_array($results[0]->getMongoIdString(), $ids));
-        $ids[] = $results[0]->getMongoIdString();
+        $this->assertFalse(in_array($results[0]->getObjectIdString(), $ids));
+        $ids[] = $results[0]->getObjectIdString();
 
         $paginator = MyService::getPaginationQueryHelper(2, 1, []);
         $this->assertEquals(3, $paginator->getTotalPages());
         $results = MyService::getPage($paginator, [], 'name', 1);
         $this->assertCount(1, $results);
-        $this->assertFalse(in_array($results[0]->getMongoIdString(), $ids));
-        $ids[] = $results[0]->getMongoIdString();
+        $this->assertFalse(in_array($results[0]->getObjectIdString(), $ids));
+        $ids[] = $results[0]->getObjectIdString();
 
         $paginator = MyService::getPaginationQueryHelper(3, 1, []);
         $this->assertEquals(3, $paginator->getTotalPages());
         $results = MyService::getPage($paginator, [], 'name', 1);
         $this->assertCount(1, $results);
-        $this->assertFalse(in_array($results[0]->getMongoIdString(), $ids));
+        $this->assertFalse(in_array($results[0]->getObjectIdString(), $ids));
 
         $paginator = MyService::getPaginationQueryHelper(1, 1, ['name' => 'Joe']);
         $this->assertEquals(2, $paginator->getTotalPages());
@@ -604,14 +604,14 @@ class ModelFunctionalityTest extends MondocBaseTest
         $ids = [];
         $results = MyService::getPage($paginator, ['name' => 'Joe'], 'name', 1);
         $this->assertCount(1, $results);
-        $this->assertFalse(in_array($results[0]->getMongoIdString(), $ids));
-        $ids[] = $results[0]->getMongoIdString();
+        $this->assertFalse(in_array($results[0]->getObjectIdString(), $ids));
+        $ids[] = $results[0]->getObjectIdString();
 
         $paginator = MyService::getPaginationQueryHelper(2, 1, ['name' => 'Joe']);
         $this->assertEquals(2, $paginator->getTotalPages());
         $results = MyService::getPage($paginator, ['name' => 'Joe'], 'name', 1);
         $this->assertCount(1, $results);
-        $this->assertFalse(in_array($results[0]->getMongoIdString(), $ids));
+        $this->assertFalse(in_array($results[0]->getObjectIdString(), $ids));
     }
 
     public function testPercentile()
@@ -631,7 +631,7 @@ class ModelFunctionalityTest extends MondocBaseTest
         }
         MyService::insertMulti($models);
         foreach ($models as $model) {
-            $this->assertTrue($model->hasMongoId());
+            $this->assertTrue($model->hasObjectId());
         }
 
         $this->assertEquals(1, MyService::aggregate()->getPercentile('age', .0));

--- a/tests/MondocTests/MondocBaseTest.php
+++ b/tests/MondocTests/MondocBaseTest.php
@@ -39,6 +39,8 @@ use District5Tests\MondocTests\Example\MySubService;
 use District5Tests\MondocTests\Example\SingleAndMultiNestedModel;
 use District5Tests\MondocTests\Example\SingleAndMultiNestedService;
 use District5Tests\MondocTests\Example\Subs\MyModelWithSub;
+use District5Tests\MondocTests\Example\VersionedModel;
+use District5Tests\MondocTests\Example\VersionedService;
 use MongoDB\Client;
 use MongoDB\Database;
 use PHPUnit\Framework\TestCase;
@@ -79,6 +81,7 @@ abstract class MondocBaseTest extends TestCase
         $this->mondoc->getDatabase()->dropCollection('test_model');
         $this->mondoc->getDatabase()->dropCollection('date_model');
         $this->mondoc->getDatabase()->dropCollection('single_and_nested_model');
+        $this->mondoc->getDatabase()->dropCollection('versioned_model');
     }
 
     protected function initMongo(): Database
@@ -102,6 +105,9 @@ abstract class MondocBaseTest extends TestCase
         )->addServiceMapping(
             SingleAndMultiNestedModel::class,
             SingleAndMultiNestedService::class
+        )->addServiceMapping(
+            VersionedModel::class,
+            VersionedService::class
         );
 
         return $this->mondoc->getDatabase();

--- a/tests/MondocTests/SingleAndNestedTest.php
+++ b/tests/MondocTests/SingleAndNestedTest.php
@@ -83,7 +83,7 @@ class SingleAndNestedTest extends MondocBaseTest
 
         $this->assertTrue($m->save());
 
-        $record = SingleAndMultiNestedService::getById($m->getMongoId());
+        $record = SingleAndMultiNestedService::getById($m->getObjectId());
         $this->assertEquals('foo', $record->getName());
         $this->assertEquals('bread', $record->getFood()->getFood());
         $this->assertEquals('white', $record->getFood()->getAttributes()[0]->getColour());

--- a/tests/MondocTests/SubModelFunctionalityTest.php
+++ b/tests/MondocTests/SubModelFunctionalityTest.php
@@ -78,7 +78,7 @@ class SubModelFunctionalityTest extends MondocBaseTest
         $this->assertArrayHasKey('wordModel', $data['age']);
 
         $m->save();
-        $id = $m->getMongoId();
+        $id = $m->getObjectId();
 
         $newM = MySubService::getById($id);
         /* @var $newM MyModelWithSub */
@@ -95,7 +95,7 @@ class SubModelFunctionalityTest extends MondocBaseTest
         $this->assertEquals('pear', $newM->getFoods()[1]->getFood());
         $this->assertEquals('oranges', $newM->getFoods()[2]->getFood());
 
-        $this->assertEquals($id->__toString(), $newM->getMongoIdString());
+        $this->assertEquals($id->__toString(), $newM->getObjectIdString());
         MySubService::getCollection(MySubService::class)->drop();
     }
 
@@ -123,11 +123,11 @@ class SubModelFunctionalityTest extends MondocBaseTest
         $mOne->save();
         $mTwo->save();
 
-        $models = MySubService::getMultiByCriteria(['_id' => ['$in' => [$mOne->getMongoId(), $mTwo->getMongoId()]]]);
+        $models = MySubService::getMultiByCriteria(['_id' => ['$in' => [$mOne->getObjectId(), $mTwo->getObjectId()]]]);
         /* @var $models MyModelWithSub[] */
 
-        $this->assertEquals($mOne->getMongoIdString(), $models[0]->getMongoIdString());
-        $this->assertEquals($mTwo->getMongoIdString(), $models[1]->getMongoIdString());
+        $this->assertEquals($mOne->getObjectIdString(), $models[0]->getObjectIdString());
+        $this->assertEquals($mTwo->getObjectIdString(), $models[1]->getObjectIdString());
         $this->assertEquals($mOne->getAge()->getAge(), $models[0]->getAge()->getAge());
         $this->assertEquals($mTwo->getAge()->getAge(), $models[1]->getAge()->getAge());
 

--- a/tests/MondocTests/VersionedModelTest.php
+++ b/tests/MondocTests/VersionedModelTest.php
@@ -1,0 +1,113 @@
+<?php /** @noinspection PhpPossiblePolymorphicInvocationInspection */
+
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests;
+
+use District5Tests\MondocTests\Example\VersionedModel;
+use District5Tests\MondocTests\Example\VersionedService;
+use MongoDB\BSON\ObjectId;
+
+/**
+ * Class VersionedModelTest.
+ *
+ * @package District5Tests\MondocTests
+ *
+ * @internal
+ */
+class VersionedModelTest extends MondocBaseTest
+{
+    public function testGetCollection()
+    {
+        $collection = VersionedService::getCollection(VersionedService::class);
+        $otherCollection = VersionedService::getCollection();
+        $this->assertEquals(
+            $collection->getCollectionName(),
+            $otherCollection->getCollectionName()
+        );
+    }
+
+    public function testInflationDeflation()
+    {
+        $data = [
+            'name' => 'Foo',
+            '_v' => 2
+        ];
+        $inflated = VersionedModel::inflateSingleArray($data);
+        $this->assertEquals('Foo', $inflated->getName());
+        $this->assertEquals(2, $inflated->getModelVersion());
+
+        $anId = new ObjectId();
+        $data = [
+            'name' => 'Foo',
+            '_v' => 2,
+            '_id' => $anId
+        ];
+        $inflated = VersionedModel::inflateSingleArray($data);
+        $this->assertEquals('Foo', $inflated->getName());
+        $this->assertEquals(2, $inflated->getModelVersion());
+        $this->assertEquals($anId->__toString(), $inflated->getObjectIdString());
+        $this->assertTrue($inflated->isModelVersionX(2));
+        $this->assertFalse($inflated->isModelVersionX(1));
+    }
+
+    public function testFullVersioningFunctionality()
+    {
+        $this->initMongo();
+
+        $m = new VersionedModel();
+        $m->setName('Foo');
+        $this->assertTrue($m->save());
+        $this->assertEquals(1, $m->getModelVersion());
+        $this->assertTrue($m->hasObjectId());
+
+        $model = VersionedService::getById($m->getObjectId());
+        /* @var $model VersionedModel */
+        $this->assertEquals(1, $model->getModelVersion());
+        $this->assertEquals('Foo', $model->getName());
+        $model->incrementModelVersion();
+        $this->assertEquals(2, $model->getModelVersion());
+        $this->assertTrue($model->save());
+
+        $model = VersionedService::getById($m->getObjectId());
+        /* @var $model VersionedModel */
+        $this->assertEquals(2, $model->getModelVersion());
+        $this->assertEquals('Foo', $model->getName());
+        $model->decrementModelVersion();
+        $this->assertEquals(1, $model->getModelVersion());
+        $this->assertTrue($model->save());
+
+        $model = VersionedService::getById($m->getObjectId());
+        /* @var $model VersionedModel */
+        $this->assertEquals(1, $model->getModelVersion());
+        $this->assertEquals('Foo', $model->getName());
+        $this->assertTrue($model->delete());
+    }
+}


### PR DESCRIPTION
### Introduce versioning trait for model

This pull request adds a `MondocVersionedModelTrait` trait, which adds a `_v` field to the `BSONDocument`.

The versioning is manual, meaning you must call either `setModelVersion($x)`, `incrementModelVersion()`, or `decrementModelVersion()` to alter the value.

**Requirements**

- [x] My code is tested.
- [x] The tests for my changes are included in this PR.
- [x] The code style is respected and followed.

