### PR TITLE
Add support for asJsonEncodableArray() exports of models

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ class Person extends MondocAbstractModel
 }
 ```
 
-Finding documents..
+#### Finding documents..
 
 ```php
 <?php
@@ -310,6 +310,27 @@ $results = \District5Tests\MondocTests\Example\MyService::getPageByByObjectIdPag
 \District5Tests\MondocTests\Example\MyService::aggregate()->getMax('age', ['foo' => 'bar']);
 // ...or with a string...
 // \District5Tests\MondocTests\Example\MyService::aggregate()->getMax('name', ['foo' => 'bar']);
+```
+
+
+#### Model to array...
+
+You can export a model to an array by calling [`asArray()`](./src/Db/Model/MondocAbstractSubModel.php) on the model.
+This will return an array of the model's properties.
+
+The properties returned by the [`asArray()`](./src/Db/Model/MondocAbstractSubModel.php) method are the properties and
+types that have been set on the model, which means they're likely not able to be directly encoded to JSON. To get around
+this, you can call [`asJsonEncodableArray()`](./src/Db/Model/MondocAbstractSubModel.php) on the model, which will return
+an array that can be encoded to JSON.
+
+```php
+/* @var $model \District5\Mondoc\Db\Model\MondocAbstractModel */
+
+$mongoInsertionDocument = $model->asArray(); // Not encodable to JSON
+$jsonEncodable = $model->asJsonEncodableArray(); // Encodable to JSON
+
+$encodedJson = json_encode($jsonEncodable, JSON_THROW_ON_ERROR);
+echo $encodedJson;
 ```
 
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,7 +31,4 @@
       <directory>tests/</directory>
     </testsuite>
   </testsuites>
-<!--  <logging>-->
-<!--    <log type="testdox-html" target="build/testdox.html"/>-->
-<!--  </logging>-->
 </phpunit>

--- a/src/Db/Model/MondocAbstractSubModel.php
+++ b/src/Db/Model/MondocAbstractSubModel.php
@@ -382,6 +382,16 @@ abstract class MondocAbstractSubModel
     /**
      * @return array
      */
+    public function asJsonEncodableArray(): array
+    {
+        return MondocTypes::typeToJsonFriendly(
+            $this->asArray()
+        );
+    }
+
+    /**
+     * @return array
+     */
     public function getMondocObjectVars(): array
     {
         return get_object_vars($this);

--- a/src/MondocConfig.php
+++ b/src/MondocConfig.php
@@ -139,6 +139,10 @@ class MondocConfig
     }
 
     /**
+     * Order is
+     *      ModelFQCN => ServiceFQCN,
+     *      AnotherModelFQCN => AnotherServiceFQCN,
+     *      ...
      * @return string[]
      */
     public function getServiceMap(): array

--- a/tests/MondocTests/Example/AbstractTestService.php
+++ b/tests/MondocTests/Example/AbstractTestService.php
@@ -30,18 +30,21 @@
 
 namespace District5Tests\MondocTests\Example;
 
+use District5\Mondoc\Db\Service\MondocAbstractService;
+
 /**
- * Class MySubService.
+ * Class AllTypesService.
  *
  * @package District5Tests\MondocTests\Service
  */
-class MySubService extends AbstractTestService
+class AbstractTestService extends MondocAbstractService
 {
     /**
      * @return string
      */
     protected static function getCollectionName(): string
     {
-        return parent::getCollectionName(); // Just an example, not needed here, but in reality, you'd just return 'my_collection_name'
+        $parts = explode('\\', get_called_class());
+        return 'test_' . array_pop($parts);
     }
 }

--- a/tests/MondocTests/Example/AllTypesModel.php
+++ b/tests/MondocTests/Example/AllTypesModel.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests\Example;
+
+use DateTime;
+use District5\Mondoc\Db\Model\MondocAbstractModel;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
+use stdClass;
+
+/**
+ * Class DateModel.
+ *
+ * @package MyNs\Model
+ */
+class AllTypesModel extends MondocAbstractModel
+{
+    protected ObjectId|null $anId = null;
+    protected string|null $string = null;
+    protected int|null $int = null;
+    protected mixed $null = null;
+    protected float|null $float = null;
+    protected bool|null $bool = null;
+    protected object|null $object = null;
+    protected DateTime|UTCDateTime|null $phpDate = null;
+    protected UTCDateTime|DateTime|null $mongoDate = null;
+    protected array|BSONArray|null $phpArray = [];
+    protected BSONArray|array $bsonArray = [];
+    protected BSONDocument|stdClass|array|null $phpObject = null;
+    protected BSONDocument|stdClass|array|null $bsonObject = null;
+
+    public function setAnId($v): void
+    {
+        $this->anId = $v;
+        $this->addDirty('anId');
+    }
+
+    public function setString($v): void
+    {
+        $this->string = $v;
+        $this->addDirty('string');
+    }
+
+    public function setInt($v): void
+    {
+        $this->int = $v;
+        $this->addDirty('int');
+    }
+
+    public function setNull($v): void
+    {
+        $this->null = $v;
+        $this->addDirty('null');
+    }
+
+    public function setFloat($v): void
+    {
+        $this->float = $v;
+        $this->addDirty('float');
+    }
+
+    public function setBool($v): void
+    {
+        $this->bool = $v;
+        $this->addDirty('bool');
+    }
+
+    public function setPhpArray($v): void
+    {
+        $this->phpArray = $v;
+        $this->addDirty('phpArray');
+    }
+
+    public function setPhpDate($v): void
+    {
+        $this->phpDate = $v;
+        $this->addDirty('phpDate');
+    }
+
+    public function setMongoDate($v): void
+    {
+        $this->mongoDate = $v;
+        $this->addDirty('mongoDate');
+    }
+
+    public function setBsonArray($v): void
+    {
+        $this->bsonArray = $v;
+        $this->addDirty('bsonArray');
+    }
+
+    public function setPhpObject($v): void
+    {
+        $this->phpObject = $v;
+        $this->addDirty('phpObject');
+    }
+
+    public function setBsonObject($v): void
+    {
+        $this->bsonObject = $v;
+        $this->addDirty('bsonObject');
+    }
+}

--- a/tests/MondocTests/Example/AllTypesService.php
+++ b/tests/MondocTests/Example/AllTypesService.php
@@ -31,11 +31,11 @@
 namespace District5Tests\MondocTests\Example;
 
 /**
- * Class MySubService.
+ * Class AllTypesService.
  *
  * @package District5Tests\MondocTests\Service
  */
-class MySubService extends AbstractTestService
+class AllTypesService extends AbstractTestService
 {
     /**
      * @return string

--- a/tests/MondocTests/Example/DateService.php
+++ b/tests/MondocTests/Example/DateService.php
@@ -30,20 +30,18 @@
 
 namespace District5Tests\MondocTests\Example;
 
-use District5\Mondoc\Db\Service\MondocAbstractService;
-
 /**
  * Class DateService.
  *
  * @package District5Tests\MondocTests\Service
  */
-class DateService extends MondocAbstractService
+class DateService extends AbstractTestService
 {
     /**
      * @return string
      */
     protected static function getCollectionName(): string
     {
-        return 'date_model';
+        return parent::getCollectionName(); // Just an example, not needed here, but in reality, you'd just return 'my_collection_name'
     }
 }

--- a/tests/MondocTests/Example/MyService.php
+++ b/tests/MondocTests/Example/MyService.php
@@ -30,20 +30,18 @@
 
 namespace District5Tests\MondocTests\Example;
 
-use District5\Mondoc\Db\Service\MondocAbstractService;
-
 /**
  * Class MyService.
  *
  * @package District5Tests\MondocTests\Service
  */
-class MyService extends MondocAbstractService
+class MyService extends AbstractTestService
 {
     /**
      * @return string
      */
     protected static function getCollectionName(): string
     {
-        return 'test_model';
+        return parent::getCollectionName(); // Just an example, not needed here, but in reality, you'd just return 'my_collection_name'
     }
 }

--- a/tests/MondocTests/Example/SingleAndMultiNestedService.php
+++ b/tests/MondocTests/Example/SingleAndMultiNestedService.php
@@ -30,20 +30,18 @@
 
 namespace District5Tests\MondocTests\Example;
 
-use District5\Mondoc\Db\Service\MondocAbstractService;
-
 /**
  * Class SingleAndMultiNestedService.
  *
  * @package District5Tests\MondocTests\Service
  */
-class SingleAndMultiNestedService extends MondocAbstractService
+class SingleAndMultiNestedService extends AbstractTestService
 {
     /**
      * @return string
      */
     protected static function getCollectionName(): string
     {
-        return 'single_and_nested_model';
+        return parent::getCollectionName(); // Just an example, not needed here, but in reality, you'd just return 'my_collection_name'
     }
 }

--- a/tests/MondocTests/Example/VersionedService.php
+++ b/tests/MondocTests/Example/VersionedService.php
@@ -30,20 +30,18 @@
 
 namespace District5Tests\MondocTests\Example;
 
-use District5\Mondoc\Db\Service\MondocAbstractService;
-
 /**
  * Class VersionedService.
  *
  * @package District5Tests\MondocTests\Service
  */
-class VersionedService extends MondocAbstractService
+class VersionedService extends AbstractTestService
 {
     /**
      * @return string
      */
     protected static function getCollectionName(): string
     {
-        return 'versioned_model';
+        return parent::getCollectionName(); // Just an example, not needed here, but in reality, you'd just return 'my_collection_name'
     }
 }

--- a/tests/MondocTests/MondocBaseTest.php
+++ b/tests/MondocTests/MondocBaseTest.php
@@ -31,6 +31,8 @@
 namespace District5Tests\MondocTests;
 
 use District5\Mondoc\MondocConfig;
+use District5Tests\MondocTests\Example\AllTypesModel;
+use District5Tests\MondocTests\Example\AllTypesService;
 use District5Tests\MondocTests\Example\DateModel;
 use District5Tests\MondocTests\Example\DateService;
 use District5Tests\MondocTests\Example\MyModel;
@@ -78,10 +80,13 @@ abstract class MondocBaseTest extends TestCase
     protected function tearDown(): void
     {
         $this->initMongo();
-        $this->mondoc->getDatabase()->dropCollection('test_model');
-        $this->mondoc->getDatabase()->dropCollection('date_model');
-        $this->mondoc->getDatabase()->dropCollection('single_and_nested_model');
-        $this->mondoc->getDatabase()->dropCollection('versioned_model');
+
+        $map = array_values($this->mondoc->getServiceMap());
+        foreach ($map as $className) {
+            $parts = explode('\\', $className);
+            $collectionName = 'test_' . array_pop($parts);
+            $this->mondoc->getDatabase()->dropCollection($collectionName);
+        }
     }
 
     protected function initMongo(): Database
@@ -108,6 +113,9 @@ abstract class MondocBaseTest extends TestCase
         )->addServiceMapping(
             VersionedModel::class,
             VersionedService::class
+        )->addServiceMapping(
+            AllTypesModel::class,
+            AllTypesService::class
         );
 
         return $this->mondoc->getDatabase();

--- a/tests/MondocTests/SubModelFunctionalityTest.php
+++ b/tests/MondocTests/SubModelFunctionalityTest.php
@@ -96,12 +96,12 @@ class SubModelFunctionalityTest extends MondocBaseTest
         $this->assertEquals('oranges', $newM->getFoods()[2]->getFood());
 
         $this->assertEquals($id->__toString(), $newM->getObjectIdString());
-        MySubService::getCollection(MySubService::class)->drop();
     }
 
     public function testMulti()
     {
-        MySubService::getCollection(MySubService::class)->drop();
+        $this->initMongo();
+
         $mOne = new MyModelWithSub();
         $mOne->setName('One');
         $ageOne = new AgeSubModel();
@@ -133,6 +133,5 @@ class SubModelFunctionalityTest extends MondocBaseTest
 
         $this->assertEquals($mOne->getFoods()[0]->getFood(), $models[0]->getFoods()[0]->getFood());
         $this->assertEquals($mTwo->getFoods()[0]->getFood(), $models[1]->getFoods()[0]->getFood());
-        MySubService::getCollection(MySubService::class)->drop();
     }
 }


### PR DESCRIPTION
### JSON encodable helper

Introduces an abstract method to easily export models as JSON friendly representations.

**Requirements**

- [x] My code is tested.
- [x] The tests for my changes are included in this PR.
- [x] The code style is respected and followed.
