### PR TITLE
Feature - Removal of addDirty

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ class MyModel extends MondocAbstractModel
     public function setName(string $val)
     {
         $this->name = trim($val);
-        $this->addDirty('name');
         return $this;
     }
 }
@@ -617,7 +616,6 @@ class MyModel extends MondocAbstractModel
     public function setName(string $name): self
     {
         $this->name = $name;
-        $this->addDirty('name');
         return $this;
     }
 }

--- a/src/Db/Model/MondocAbstractModel.php
+++ b/src/Db/Model/MondocAbstractModel.php
@@ -104,7 +104,7 @@ class MondocAbstractModel extends MondocAbstractSubModel
      *
      * @return $this
      */
-    private function setOriginalBsonDocument(BSONDocument $document): MondocAbstractModel
+    public function setOriginalBsonDocument(BSONDocument $document): MondocAbstractModel
     {
         $this->_mondocBson = $document;
 

--- a/src/Db/Model/MondocAbstractSubModel.php
+++ b/src/Db/Model/MondocAbstractSubModel.php
@@ -333,7 +333,13 @@ abstract class MondocAbstractSubModel
      */
     public function getMondocObjectVars(): array
     {
-        return get_object_vars($this);
+        $vars = get_object_vars($this);
+        $ignore = $this->getPropertyExclusions();
+        foreach ($ignore as $i) {
+            unset($vars[$i]);
+        }
+
+        return $vars;
     }
 
     /**

--- a/src/Db/Service/Traits/Persistence/InsertSingleTrait.php
+++ b/src/Db/Service/Traits/Persistence/InsertSingleTrait.php
@@ -34,6 +34,7 @@ use District5\Mondoc\Db\Model\MondocAbstractModel;
 use District5\Mondoc\Exception\MondocConfigConfigurationException;
 use District5\Mondoc\Exception\MondocServiceMapErrorException;
 use District5\Mondoc\Extensions\Retention\MondocRetentionService;
+use MongoDB\Model\BSONDocument;
 
 /**
  * Trait InsertSingleTrait.
@@ -73,6 +74,8 @@ trait InsertSingleTrait
             $model->setObjectId($insert->getInsertedId());
             $model->setMongoCollection($collection);
             $model->clearDirty();
+            $data['_id'] = $model->getObjectId();
+            $model->setOriginalBsonDocument(new BSONDocument($data));
 
             if ($model->isMondocRetentionEnabled()) {
                 MondocRetentionService::create($model);

--- a/src/Db/Service/Traits/Persistence/UpdateSingleTrait.php
+++ b/src/Db/Service/Traits/Persistence/UpdateSingleTrait.php
@@ -65,6 +65,9 @@ trait UpdateSingleTrait
         $data = $model->asArray();
         unset($data['_id']);
         $dirty = $model->getDirty();
+        if (empty($dirty)) {
+            return true;
+        }
         $changeSet = [];
         foreach ($dirty as $key) {
             $key = $model->getFieldAliasSingleMap($key, true);

--- a/src/Extensions/Retention/MondocRetentionModel.php
+++ b/src/Extensions/Retention/MondocRetentionModel.php
@@ -125,7 +125,6 @@ class MondocRetentionModel extends MondocAbstractModel
     public function setSourceModelData(array|BSONDocument $data): static
     {
         $this->doc = MondocTypes::arrayToPhp($data);
-        $this->addDirty('doc');
 
         return $this;
     }
@@ -147,13 +146,12 @@ class MondocRetentionModel extends MondocAbstractModel
     }
 
     /**
-     * @param ObjectId $srcId
+     * @param ObjectId $id
      * @return $this
      */
-    public function setSourceObjectId(ObjectId $srcId): static
+    public function setSourceObjectId(ObjectId $id): static
     {
-        $this->id = $srcId;
-        $this->addDirty('id');
+        $this->id = $id;
 
         return $this;
     }
@@ -173,7 +171,6 @@ class MondocRetentionModel extends MondocAbstractModel
     public function setSourceClassName(string $class): static
     {
         $this->class = $class;
-        $this->addDirty('srcClass');
 
         return $this;
     }
@@ -195,7 +192,6 @@ class MondocRetentionModel extends MondocAbstractModel
     public function setRetentionData(array $retention): static
     {
         $this->retention = MondocTypes::arrayToPhp($retention);
-        $this->addDirty('retention');
 
         return $this;
     }
@@ -223,7 +219,6 @@ class MondocRetentionModel extends MondocAbstractModel
     public function setRetentionExpiry(DateTime|UTCDateTime|null $expiry): static
     {
         $this->expiry = $expiry;
-        $this->addDirty('expiry');
 
         return $this;
     }

--- a/src/Helper/Traits/ObjectIdConversionTrait.php
+++ b/src/Helper/Traits/ObjectIdConversionTrait.php
@@ -105,7 +105,8 @@ trait ObjectIdConversionTrait
     {
         $tmp = [];
         $final = [];
-        foreach ($ids as $id) {
+        $arrayOfIds = self::arrayOfObjectIdsToObjectIds($ids);
+        foreach ($arrayOfIds as $id) {
             $newId = self::toObjectId($id);
             if (null !== $newId && !in_array($stringId = MondocTypes::objectIdToString($newId), $tmp)) {
                 $final[] = $newId;
@@ -114,5 +115,24 @@ trait ObjectIdConversionTrait
         }
 
         return $final;
+    }
+
+    /**
+     * Given an array of ObjectIds, this will ensure they are indeed ObjectIds.
+     *
+     * @param array $data
+     *
+     * @return ObjectId[]
+     */
+    public static function arrayOfObjectIdsToObjectIds(array $data): array
+    {
+        $n = [];
+        foreach ($data as $i) {
+            if (null !== $id = self::toObjectId($i)) {
+                $n[] = $id;
+            }
+        }
+
+        return array_values($n);
     }
 }

--- a/tests/MondocTests/FunctionalityParts/InsertionTest.php
+++ b/tests/MondocTests/FunctionalityParts/InsertionTest.php
@@ -105,19 +105,18 @@ class InsertionTest extends MondocBaseTest
         $m->setAge(1);
         $m->setName(uniqid());
         $this->assertTrue($m->save());
-        $this->assertTrue($m->save()); // subsequent saves should not cause an issue and return true
-        $this->assertTrue($m->save());
-        $this->assertTrue($m->save());
-        $this->assertTrue($m->save());
 
         $model = MyService::getById($m->getObjectId());
-        $model->proxyAddDirty('car', 'ford');
+        $model->proxyAddDirty('car');
+        $model->proxySetKey('bestTv', 'A-Team');
         $model->save();
 
         $another = MyService::getById($m->getObjectId());
         $arrayCopy = $another->getOriginalBsonDocument()->getArrayCopy();
         $this->assertArrayHasKey('car', $arrayCopy);
+        $this->assertArrayHasKey('bestTv', $arrayCopy);
         $this->assertNull($arrayCopy['car']); // invalid keys are not saved
+        $this->assertEquals('A-Team', $arrayCopy['bestTv']);
 
 
         $another->setAge(2);

--- a/tests/MondocTests/ModelFunctionalityTest.php
+++ b/tests/MondocTests/ModelFunctionalityTest.php
@@ -93,6 +93,28 @@ class ModelFunctionalityTest extends MondocBaseTest
      * @throws MondocServiceMapErrorException
      * @throws MondocConfigConfigurationException
      */
+    public function testInsertionAndBSONArePresent()
+    {
+        $m = new MyModel();
+        $m->setAge(2);
+        $m->setName('Joe');
+        $dirty = $m->getDirty();
+        $this->assertCount(2, $dirty);
+        $this->assertNull($m->getOriginalBsonDocument());
+        $this->assertTrue($m->save());
+
+        $this->assertEmpty($m->getDirty());
+        $this->assertNotNull($m->getOriginalBsonDocument());
+        $this->assertEquals(2, $m->getOriginalBsonDocument()->getArrayCopy()['age']);
+        $this->assertEquals('Joe', $m->getOriginalBsonDocument()->getArrayCopy()['name']);
+
+        $this->assertTrue($m->delete());
+    }
+
+    /**
+     * @throws MondocServiceMapErrorException
+     * @throws MondocConfigConfigurationException
+     */
     public function testDeleteWorksAsExpected()
     {
         $m = new MyModel();
@@ -100,6 +122,7 @@ class ModelFunctionalityTest extends MondocBaseTest
         $m->setName('Joe');
         $this->assertTrue($m->save());
         $this->assertTrue($m->hasObjectId());
+        $this->assertTrue($m->save());
         $this->assertTrue($m->delete());
         $this->assertFalse($m->hasObjectId());
 

--- a/tests/MondocTests/RetainedDataModelTest.php
+++ b/tests/MondocTests/RetainedDataModelTest.php
@@ -181,7 +181,7 @@ class RetainedDataModelTest extends MondocBaseTest
 
         $totalLoops = 10;
         for ($i = 1; $i < ($totalLoops + 1); $i++) {
-            $m->setName('foo');
+            $m->setName('foo' . $i);
             $this->assertTrue($m->save());
             $this->assertEquals($i + 2, MondocRetentionService::countRetentionModelsForClassName(TopLevelRetainedTestModel::class));
         }

--- a/tests/MondocTests/TestObjects/Model/AllTypesModel.php
+++ b/tests/MondocTests/TestObjects/Model/AllTypesModel.php
@@ -62,7 +62,6 @@ class AllTypesModel extends MondocAbstractModel
     public function setAnId($v): void
     {
         $this->anId = $v;
-        $this->addDirty('anId');
     }
 
     /**
@@ -79,66 +78,55 @@ class AllTypesModel extends MondocAbstractModel
     public function setString($v): void
     {
         $this->string = $v;
-        $this->addDirty('string');
     }
 
     public function setInt($v): void
     {
         $this->int = $v;
-        $this->addDirty('int');
     }
 
     public function setNull($v): void
     {
         $this->null = $v;
-        $this->addDirty('null');
     }
 
     public function setFloat($v): void
     {
         $this->float = $v;
-        $this->addDirty('float');
     }
 
     public function setBool($v): void
     {
         $this->bool = $v;
-        $this->addDirty('bool');
     }
 
     public function setPhpArray($v): void
     {
         $this->phpArray = $v;
-        $this->addDirty('phpArray');
     }
 
     public function setPhpDate($v): void
     {
         $this->phpDate = $v;
-        $this->addDirty('phpDate');
     }
 
     public function setMongoDate($v): void
     {
         $this->mongoDate = $v;
-        $this->addDirty('mongoDate');
     }
 
     public function setBsonArray($v): void
     {
         $this->bsonArray = $v;
-        $this->addDirty('bsonArray');
     }
 
     public function setPhpObject($v): void
     {
         $this->phpObject = $v;
-        $this->addDirty('phpObject');
     }
 
     public function setBsonObject($v): void
     {
         $this->bsonObject = $v;
-        $this->addDirty('bsonObject');
     }
 }

--- a/tests/MondocTests/TestObjects/Model/DateModel.php
+++ b/tests/MondocTests/TestObjects/Model/DateModel.php
@@ -64,7 +64,6 @@ class DateModel extends MondocAbstractModel
     public function setDate(DateTime $date): static
     {
         $this->date = $date;
-        $this->addDirty('date');
 
         return $this;
     }

--- a/tests/MondocTests/TestObjects/Model/FieldAliasTestModel.php
+++ b/tests/MondocTests/TestObjects/Model/FieldAliasTestModel.php
@@ -85,7 +85,6 @@ class FieldAliasTestModel extends MondocAbstractModel
     public function setAttributes(FieldAliasSubModel $attributes): static
     {
         $this->attributes = $attributes;
-        $this->addDirty('attributes');
         return $this;
     }
 
@@ -105,7 +104,6 @@ class FieldAliasTestModel extends MondocAbstractModel
     public function setMultiAttributes(array $multiAttributes): static
     {
         $this->multiAttributes = $multiAttributes;
-        $this->addDirty('multiAttributes');
         return $this;
     }
 
@@ -133,7 +131,6 @@ class FieldAliasTestModel extends MondocAbstractModel
     public function setName(string $name): static
     {
         $this->name = $name;
-        $this->addDirty('name');
         return $this;
     }
 
@@ -153,7 +150,6 @@ class FieldAliasTestModel extends MondocAbstractModel
     public function setCity(string $city): static
     {
         $this->city = $city;
-        $this->addDirty('city');
         return $this;
     }
 
@@ -173,7 +169,6 @@ class FieldAliasTestModel extends MondocAbstractModel
     public function setAge(int $age): static
     {
         $this->age = $age;
-        $this->addDirty('age');
         return $this;
     }
 }

--- a/tests/MondocTests/TestObjects/Model/FinancialCandleModel.php
+++ b/tests/MondocTests/TestObjects/Model/FinancialCandleModel.php
@@ -75,7 +75,6 @@ class FinancialCandleModel extends MondocAbstractModel
     public function setDate(DateTime $date): static
     {
         $this->date = $date;
-        $this->addDirty('date');
 
         return $this;
     }
@@ -96,7 +95,6 @@ class FinancialCandleModel extends MondocAbstractModel
     public function setPrice(float|int $price): static
     {
         $this->price = $price;
-        $this->addDirty('price');
 
         return $this;
     }
@@ -117,7 +115,6 @@ class FinancialCandleModel extends MondocAbstractModel
     public function setSymbol(string|null $symbol): static
     {
         $this->symbol = $symbol;
-        $this->addDirty('symbol');
 
         return $this;
     }

--- a/tests/MondocTests/TestObjects/Model/HelperTraitsModel.php
+++ b/tests/MondocTests/TestObjects/Model/HelperTraitsModel.php
@@ -55,7 +55,6 @@ class HelperTraitsModel extends AbstractHelperTraitsModel
     public function setName(string $name): self
     {
         $this->name = $name;
-        $this->addDirty('name');
         return $this;
     }
 

--- a/tests/MondocTests/TestObjects/Model/HelperTraitsOtherModel.php
+++ b/tests/MondocTests/TestObjects/Model/HelperTraitsOtherModel.php
@@ -60,7 +60,6 @@ class HelperTraitsOtherModel extends MondocAbstractModel
     public function setName(string $name): self
     {
         $this->name = $name;
-        $this->addDirty('name');
         return $this;
     }
 

--- a/tests/MondocTests/TestObjects/Model/MyDuplicateModel.php
+++ b/tests/MondocTests/TestObjects/Model/MyDuplicateModel.php
@@ -68,7 +68,6 @@ class MyDuplicateModel extends MondocAbstractModel
     public function setName(string $val): static
     {
         $this->name = trim($val);
-        $this->addDirty('name');
 
         return $this;
     }
@@ -89,7 +88,6 @@ class MyDuplicateModel extends MondocAbstractModel
     public function setAge(int $age): static
     {
         $this->age = $age;
-        $this->addDirty('age');
 
         return $this;
     }

--- a/tests/MondocTests/TestObjects/Model/MyModel.php
+++ b/tests/MondocTests/TestObjects/Model/MyModel.php
@@ -95,12 +95,9 @@ class MyModel extends MondocAbstractModel
                 'age' => $this->getAge(),
                 'foo' => 'bar'
             ];
-        } else {
-            return [
-                'name' => $this->getName(),
-                'age' => $this->getAge()
-            ];
         }
+
+        return parent::asArray();
     }
 
     /**
@@ -129,7 +126,6 @@ class MyModel extends MondocAbstractModel
     public function setName(string $val): static
     {
         $this->name = trim($val);
-        $this->addDirty('name');
 
         return $this;
     }
@@ -150,7 +146,6 @@ class MyModel extends MondocAbstractModel
     public function setAge(int $age): static
     {
         $this->age = $age;
-        $this->addDirty('age');
 
         return $this;
     }
@@ -189,12 +184,23 @@ class MyModel extends MondocAbstractModel
      * Hack to allow it through for tests
      *
      * @param string $property
-     * @param string $value
      * @return void
      */
-    public function proxyAddDirty(string $property, string $value): void
+    public function proxyAddDirty(string $property): void
     {
         $this->addDirty($property);
+    }
+
+    /**
+     * Hack to allow it through for tests
+     *
+     * @param string $property
+     * @param mixed $value
+     * @return void
+     */
+    public function proxySetKey(string $property, mixed $value): void
+    {
+        $this->__set($property, $value);
     }
 
     /**

--- a/tests/MondocTests/TestObjects/Model/MyModelWithSub.php
+++ b/tests/MondocTests/TestObjects/Model/MyModelWithSub.php
@@ -92,7 +92,6 @@ class MyModelWithSub extends MondocAbstractModel
     public function setAge(AgeSubModel $age): static
     {
         $this->age = $age;
-        $this->addDirty('age');
 
         return $this;
     }
@@ -113,7 +112,6 @@ class MyModelWithSub extends MondocAbstractModel
     public function setName(string $val): static
     {
         $this->name = trim($val);
-        $this->addDirty('name');
 
         return $this;
     }

--- a/tests/MondocTests/TestObjects/Model/NoServiceModel.php
+++ b/tests/MondocTests/TestObjects/Model/NoServiceModel.php
@@ -51,7 +51,6 @@ class NoServiceModel extends MondocAbstractModel
     public function setName(string $name): self
     {
         $this->name = $name;
-        $this->addDirty('name');
         return $this;
     }
 

--- a/tests/MondocTests/TestObjects/Model/SingleAndMultiNestedModel.php
+++ b/tests/MondocTests/TestObjects/Model/SingleAndMultiNestedModel.php
@@ -82,7 +82,6 @@ class SingleAndMultiNestedModel extends MondocAbstractModel
     public function setFriends(array $friends): void
     {
         $this->friends = $friends;
-        $this->addDirty('friends');
     }
 
     /**
@@ -98,7 +97,6 @@ class SingleAndMultiNestedModel extends MondocAbstractModel
      */
     public function setFood(?FoodSubModel $food): void
     {
-        $this->addDirty('food');
         $this->food = $food;
     }
 
@@ -115,7 +113,6 @@ class SingleAndMultiNestedModel extends MondocAbstractModel
      */
     public function setFoods(array $foods): void
     {
-        $this->addDirty('foods');
         $this->foods = $foods;
     }
 
@@ -133,7 +130,6 @@ class SingleAndMultiNestedModel extends MondocAbstractModel
     public function setName(string $name): void
     {
         $this->name = $name;
-        $this->addDirty('name');
     }
 
     /**

--- a/tests/MondocTests/TestObjects/Model/SubLevelRetainedTestModel.php
+++ b/tests/MondocTests/TestObjects/Model/SubLevelRetainedTestModel.php
@@ -72,7 +72,6 @@ class SubLevelRetainedTestModel extends AbstractRetainedTestModel
     public function setName(string $name): SubLevelRetainedTestModel
     {
         $this->name = $name;
-        $this->addDirty('name');
         return $this;
     }
 
@@ -92,7 +91,6 @@ class SubLevelRetainedTestModel extends AbstractRetainedTestModel
     public function setAge(AgeSubModel $age): SubLevelRetainedTestModel
     {
         $this->age = $age;
-        $this->addDirty('age');
         return $this;
     }
 }

--- a/tests/MondocTests/TestObjects/Model/TopLevelRetainedTestModel.php
+++ b/tests/MondocTests/TestObjects/Model/TopLevelRetainedTestModel.php
@@ -63,7 +63,6 @@ class TopLevelRetainedTestModel extends MondocAbstractModel
     public function setName(string $name): TopLevelRetainedTestModel
     {
         $this->name = $name;
-        $this->addDirty('name');
         return $this;
     }
 }

--- a/tests/MondocTests/TestObjects/Service/SingleAndMultiNestedService.php
+++ b/tests/MondocTests/TestObjects/Service/SingleAndMultiNestedService.php
@@ -31,12 +31,27 @@
 namespace District5Tests\MondocTests\TestObjects\Service;
 
 use District5\Mondoc\Exception\MondocConfigConfigurationException;
+use District5\Mondoc\Helper\MondocPaginationHelper;
+use District5\MondocBuilder\QueryBuilder;
+use District5Tests\MondocTests\TestObjects\Model\SingleAndMultiNestedModel;
 use MongoDB\BSON\ObjectId;
 
 /**
  * Class SingleAndMultiNestedService.
  *
  * @package District5Tests\MondocTests\TestObjects\Service
+ * @method static SingleAndMultiNestedModel[] getMultiByCriteria(array $filter = [], array $options = [])
+ * @method static SingleAndMultiNestedModel[] getMultiByQueryBuilder(QueryBuilder $builder)
+ * @method static SingleAndMultiNestedModel[] getByIds(array $ids)
+ * @method static SingleAndMultiNestedModel[] getMultiWhereKeyEqualsValue(string $key, $value)
+ * @method static SingleAndMultiNestedModel[] getMultiWhereKeyDoesNotEqualValue(string $key, $value)
+ * @method static SingleAndMultiNestedModel|null getOneByCriteria(array $filter = [], array $options = [])
+ * @method static SingleAndMultiNestedModel|null getById(ObjectId|string $id)
+ * @method static SingleAndMultiNestedModel|null getOneByQueryBuilder(QueryBuilder $builder)
+ * @method static SingleAndMultiNestedModel|null getOneWhereKeyEqualsValue(string $key, mixed $value)
+ * @method static SingleAndMultiNestedModel|null getOneWhereKeyDoesNotEqualValue(string $key, mixed $value)
+ * @method static SingleAndMultiNestedModel[] getPage(MondocPaginationHelper $paginator, ?string $sortByField = '_id', int $sortDirection = -1): array
+ * @method static SingleAndMultiNestedModel[] getPageByByObjectIdPagination(MondocPaginationHelper $paginator, ObjectId|string|null $currentId, int $sortDirection = -1, array $filter = [])
  */
 class SingleAndMultiNestedService extends AbstractTestService
 {


### PR DESCRIPTION
### Removal of addDirty requirement

This is a feature change of Mondoc. It removes the requirement of using the `addDirty` method to indicate when a field is dirty.

**Flags**

- [ ] This is a breaking change.
- [x] This is a new feature.
- [ ] This is a bug fix.

**Requirements**

- [x] This is a pull request.
- [x] My code is tested.
- [x] The tests for my changes are included in this PR.
- [x] The code style is respected and followed.

### More information (if required)

The `addDirty` method was a necessity in earlier versions of Mondoc, but as planned with `6.5.0`, the removal of the requirement has been executed.

The method is still available, so that properties can be explicitly marked as dirty, but using it is entirely optional, and will only be required in a handful of cases.
