### PR TITLE
Fixes issue #13

### DIFF
--- a/src/Db/Model/Traits/DirtyAttributesTrait.php
+++ b/src/Db/Model/Traits/DirtyAttributesTrait.php
@@ -138,7 +138,7 @@ trait DirtyAttributesTrait
         }
         $bsonValues = $this->getOriginalBsonDocument()->getArrayCopy();
         if (!array_key_exists($property, $bsonValues)) {
-            return array_key_exists($property, $this->getUnmappedFields()); // check if it's in the unmapped fields
+            return true;
         }
 
         return MondocTypes::typeToJsonFriendly($this->__get($property)) !== MondocTypes::typeToJsonFriendly($bsonValues[$property]);

--- a/tests/MondocTests/TestNewFieldIntroductionTest.php
+++ b/tests/MondocTests/TestNewFieldIntroductionTest.php
@@ -1,0 +1,131 @@
+<?php /** @noinspection PhpPossiblePolymorphicInvocationInspection */
+
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests;
+
+use DateTime;
+use District5\Mondoc\Db\Model\MondocAbstractModel;
+use District5\Mondoc\Db\Service\MondocAbstractService;
+use District5\Mondoc\Exception\MondocConfigConfigurationException;
+use District5\Mondoc\Exception\MondocServiceMapErrorException;
+use District5\Mondoc\Helper\MondocTypes;
+use District5\MondocBuilder\QueryBuilder;
+use District5\MondocBuilder\QueryTypes\ValueEqualTo;
+use District5Tests\MondocTests\TestObjects\Model\DateModel;
+use District5Tests\MondocTests\TestObjects\Model\MyModel;
+use District5Tests\MondocTests\TestObjects\Model\NoServiceModel;
+use District5Tests\MondocTests\TestObjects\ModelChanges\FooModel;
+use District5Tests\MondocTests\TestObjects\ModelChanges\FooService;
+use District5Tests\MondocTests\TestObjects\ModelChanges\FooWithMoreFieldsModel;
+use District5Tests\MondocTests\TestObjects\ModelChanges\FooWithMoreFieldsService;
+use District5Tests\MondocTests\TestObjects\Service\DateService;
+use District5Tests\MondocTests\TestObjects\Service\MyService;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
+
+/**
+ * Class TestNewFieldIntroductionTest.
+ *
+ * @package District5Tests\MondocTests
+ *
+ * @internal
+ */
+class TestNewFieldIntroductionTest extends MondocBaseTestAbstract
+{
+    /**
+     * @return void
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     */
+    public function testBasicModel()
+    {
+        $m = new FooModel();
+        $m->setName('foo');
+        $this->assertTrue($m->save());
+
+        $retrieved = FooService::getById($m->getObjectId());
+        $this->assertEquals($retrieved->getObjectIdString(), $m->getObjectIdString());
+        $this->assertEquals($retrieved->getName(), $m->getName());
+
+        $this->assertTrue($m->delete());
+    }
+
+    /**
+     * @return void
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     */
+    public function testOtherBasicModelWithSameCollection()
+    {
+        $m = new FooWithMoreFieldsModel();
+        $m->setName('foo');
+        $m->setAge(39);
+        $m->setData(['foo' => 'bar']);
+        $this->assertTrue($m->save());
+
+        $retrieved = FooWithMoreFieldsService::getById($m->getObjectId());
+        $this->assertEquals($retrieved->getObjectIdString(), $m->getObjectIdString());
+        $this->assertEquals($retrieved->getName(), $m->getName());
+        $this->assertEquals($retrieved->getAge(), $m->getAge());
+        $this->assertEquals($retrieved->getData(), $m->getData());
+
+        $this->assertTrue($m->delete());
+    }
+
+    public function testSavingWithFooThenIntroducingArray()
+    {
+        $m = new FooModel();
+        $m->setName('foo');
+        $this->assertTrue($m->save());
+
+        $retrieved = FooWithMoreFieldsService::getById($m->getObjectId()); // different model
+        $this->assertEquals($retrieved->getObjectIdString(), $m->getObjectIdString());
+
+        $retrieved->setData(['foo' => 'bar']);
+        $retrieved->setAge(40);
+        $this->assertTrue($retrieved->save());
+
+        $retrieved = FooWithMoreFieldsService::getById($m->getObjectId());
+        $this->assertEquals($retrieved->getOriginalBsonDocument()->data->foo, 'bar');
+        $this->assertEquals($retrieved->getOriginalBsonDocument()->name, 'foo');
+        $this->assertEquals($retrieved->getOriginalBsonDocument()->age, 40);
+        $this->assertEquals($retrieved->getAge(), 40);
+    }
+
+    /**
+     * @return void
+     * @throws MondocConfigConfigurationException
+     */
+    protected function tearDown(): void
+    {
+        MyService::deleteMulti([]);
+    }
+}

--- a/tests/MondocTests/TestObjects/ModelChanges/FooModel.php
+++ b/tests/MondocTests/TestObjects/ModelChanges/FooModel.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests\TestObjects\ModelChanges;
+
+use District5\Mondoc\Db\Model\MondocAbstractModel;
+
+/**
+ * Class FooModel
+ *
+ * @package District5Tests\MondocTests\TestObjects\Model
+ */
+class FooModel extends MondocAbstractModel
+{
+    protected string $name = '';
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/MondocTests/TestObjects/ModelChanges/FooService.php
+++ b/tests/MondocTests/TestObjects/ModelChanges/FooService.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests\TestObjects\ModelChanges;
+
+use District5Tests\MondocTests\TestObjects\Service\AbstractTestService;
+
+/**
+ * Class FooService.
+ *
+ * @package District5Tests\MondocTests\TestObjects\Service
+ */
+class FooService extends AbstractTestService
+{
+    /**
+     * @return string
+     */
+    protected static function getCollectionName(): string
+    {
+        return 'test_foo';
+    }
+}

--- a/tests/MondocTests/TestObjects/ModelChanges/FooWithMoreFieldsModel.php
+++ b/tests/MondocTests/TestObjects/ModelChanges/FooWithMoreFieldsModel.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests\TestObjects\ModelChanges;
+
+use District5\Mondoc\Db\Model\MondocAbstractModel;
+
+/**
+ * Class FooWithMoreFieldsModel
+ *
+ * @package District5Tests\MondocTests\TestObjects\Model
+ */
+class FooWithMoreFieldsModel extends MondocAbstractModel
+{
+    protected string $name = '';
+
+    protected int $age = 0;
+
+    protected array $data = [];
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getAge(): int
+    {
+        return $this->age;
+    }
+
+    public function setAge(int $age): void
+    {
+        $this->age = $age;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function setData(array $data): void
+    {
+        $this->data = $data;
+    }
+}

--- a/tests/MondocTests/TestObjects/ModelChanges/FooWithMoreFieldsService.php
+++ b/tests/MondocTests/TestObjects/ModelChanges/FooWithMoreFieldsService.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests\TestObjects\ModelChanges;
+
+use District5Tests\MondocTests\TestObjects\Service\AbstractTestService;
+
+/**
+ * Class FooWithMoreFieldsService.
+ *
+ * @package District5Tests\MondocTests\TestObjects\Service
+ */
+class FooWithMoreFieldsService extends AbstractTestService
+{
+    /**
+     * @return string
+     */
+    protected static function getCollectionName(): string
+    {
+        return 'test_foo';
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,10 @@ use District5Tests\MondocTests\TestObjects\Model\TopLevelRetainedTestModel;
 use District5Tests\MondocTests\TestObjects\Model\SingleAndMultiNestedModel;
 use District5Tests\MondocTests\TestObjects\Model\HelperTraitsModel;
 use District5Tests\MondocTests\TestObjects\Model\HelperTraitsOtherModel;
+use District5Tests\MondocTests\TestObjects\ModelChanges\FooModel;
+use District5Tests\MondocTests\TestObjects\ModelChanges\FooService;
+use District5Tests\MondocTests\TestObjects\ModelChanges\FooWithMoreFieldsModel;
+use District5Tests\MondocTests\TestObjects\ModelChanges\FooWithMoreFieldsService;
 use District5Tests\MondocTests\TestObjects\Service\AllTypesService;
 use District5Tests\MondocTests\TestObjects\Service\DateService;
 use District5Tests\MondocTests\TestObjects\Service\FieldAliasTestService;
@@ -65,18 +69,29 @@ $mondoc->addServiceMapping(
 )->addServiceMapping(
     SubLevelRetainedTestModel::class,
     SubLevelRetainedTestService::class
+)->addServiceMapping(
+    FooModel::class,
+    FooService::class
+)->addServiceMapping(
+    FooWithMoreFieldsModel::class,
+    FooWithMoreFieldsService::class
 ); // just to cover the addServiceMapping method
 
 function cleanupCollections($mondoc): void
 {
     $map = array_values($mondoc->getServiceMap());
     foreach ($map as $className) {
+        if ($className === FooService::class || $className === FooWithMoreFieldsService::class) {
+            continue; // Skip the test classes
+        }
         $parts = explode('\\', $className);
         $collectionName = 'test_' . array_pop($parts);
         $mondoc->getDatabase()->dropCollection($collectionName);
     }
     $mondoc->getDatabase()->dropCollection('mondoc_retention');
 }
+
+$mondoc->getDatabase()->dropCollection('test_foo'); // Drop the test collection
 
 cleanupCollections($mondoc); // Start with a clean slate
 try {


### PR DESCRIPTION
This PR fixes #13 - allows for new fields to be introduced to models without the requirement of leveraging `addDirty` method, as this shall be removed from Mondoc in a future version.
