### PR TITLE
Hooks and scopes implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Usage...
 
 #### Setting up connections...
 
-The `MondoConnections` object is a singleton. Set this up somewhere in your code to initialise the connection, and
+The `MondocConfig` object is a singleton. Set this up somewhere in your code to initialize the connection, and
 within your services you can define `protected static function getConnectionId(): string` to return the correct
 identifier for the relevant model.
 
@@ -676,6 +676,115 @@ $results = MondocRetentionService::getPage(
 // This will return the `MongoRetentionModel` for the `MyModel` with the user `joe.bloggs`
 $firstResultInflated = $results[0]->toOriginalModel();
 echo $firstResultInflated->getName(); // John Doe
+```
+
+#### Lifecycle hooks
+
+Models support six lifecycle hooks that fire around insert, update, and delete operations. Override any of them in
+your model to run custom logic or veto the operation by returning `false` from a `before*` hook.
+
+| Method           | Return | Description                         |
+|------------------|--------|-------------------------------------|
+| `beforeInsert()` | `bool` | Return `false` to cancel the insert |
+| `afterInsert()`  | `void` | Called after a successful insert    |
+| `beforeUpdate()` | `bool` | Return `false` to cancel the update |
+| `afterUpdate()`  | `void` | Called after a successful update    |
+| `beforeDelete()` | `bool` | Return `false` to cancel the delete |
+| `afterDelete()`  | `void` | Called after a successful delete    |
+
+```php
+<?php
+use District5\Mondoc\Db\Model\MondocAbstractModel;
+
+class MyModel extends MondocAbstractModel
+{
+    protected string $name = '';
+    protected bool $active = true;
+
+    // Prevent inserting a model with an empty name
+    public function beforeInsert(): bool
+    {
+        return $this->name !== '';
+    }
+
+    // Stamp a modification time after every successful update
+    public function afterUpdate(): void
+    {
+        // e.g. log, notify, dispatch an event...
+    }
+
+    // Prevent deleting active records
+    public function beforeDelete(): bool
+    {
+        return !$this->active;
+    }
+}
+
+$model = new MyModel();
+$model->setName(''); // empty name
+$model->save(); // returns false — beforeInsert vetoed the insert
+
+$model->setName('Alice');
+$model->save(); // returns true — inserted successfully
+```
+
+Hooks also fire per-model when using `insertMulti()`. Any model whose `beforeInsert()` returns `false` is silently
+skipped; the rest are inserted as normal.
+
+```php
+<?php
+$alice = new MyModel();
+$alice->setName('Alice');
+
+$noName = new MyModel();
+// setName not called — beforeInsert will veto this one
+
+MyService::insertMulti([$alice, $noName]);
+// $alice is inserted and $alice->hasObjectId() === true
+// $noName is skipped and $noName->hasObjectId() === false
+```
+
+#### Query scopes
+
+Services support named, reusable filter criteria called scopes. Override `getScopes()` in your service to define them,
+then use `scope()` to retrieve the filter for one or more scope names. Use `mergeFilters()` to combine scope filters
+with additional criteria.
+
+```php
+<?php
+use District5\Mondoc\Db\Service\MondocAbstractService;
+
+class UserService extends MondocAbstractService
+{
+    protected static function getCollectionName(): string
+    {
+        return 'users';
+    }
+
+    protected static function getScopes(): array
+    {
+        return [
+            'adults'  => ['age' => ['$gte' => 18]],
+            'active'  => ['active' => true],
+            'premium' => ['plan' => 'premium'],
+        ];
+    }
+}
+
+// Single scope
+$filter = UserService::scope('adults');
+$adults = UserService::getMultiByCriteria($filter);
+
+// Multiple scopes merged together
+$filter = UserService::scope('adults', 'active');
+$activeAdults = UserService::getMultiByCriteria($filter);
+
+// Combine a scope with extra criteria
+$filter = UserService::mergeFilters(
+    UserService::scope('adults', 'active'),
+    ['country' => 'GB']
+);
+$gbActiveAdults = UserService::getMultiByCriteria($filter);
 ```
 
 #### Query building

--- a/src/Db/Model/MondocAbstractModel.php
+++ b/src/Db/Model/MondocAbstractModel.php
@@ -146,6 +146,63 @@ class MondocAbstractModel extends MondocAbstractSubModel
     }
 
     /**
+     * Called before this model is inserted. Return false to cancel the insert.
+     *
+     * @return bool
+     */
+    public function beforeInsert(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Called after this model has been successfully inserted.
+     *
+     * @return void
+     */
+    public function afterInsert(): void
+    {
+    }
+
+    /**
+     * Called before this model is updated. Return false to cancel the update.
+     *
+     * @return bool
+     */
+    public function beforeUpdate(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Called after this model has been successfully updated.
+     *
+     * @return void
+     */
+    public function afterUpdate(): void
+    {
+    }
+
+    /**
+     * Called before this model is deleted. Return false to cancel the delete.
+     *
+     * @return bool
+     */
+    public function beforeDelete(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Called after this model has been successfully deleted.
+     *
+     * @return void
+     */
+    public function afterDelete(): void
+    {
+    }
+
+    /**
      * @return bool
      */
     final public function isMondocModel(): bool

--- a/src/Db/Service/MondocAbstractService.php
+++ b/src/Db/Service/MondocAbstractService.php
@@ -137,6 +137,46 @@ abstract class MondocAbstractService
     }
 
     /**
+     * Returns the named query scopes for this service. Override in subclasses to define reusable filters.
+     *
+     * @return array<string, array>
+     */
+    protected static function getScopes(): array
+    {
+        return [];
+    }
+
+    /**
+     * Merge multiple filter arrays into a single filter array.
+     *
+     * @param array ...$filters
+     * @return array
+     */
+    public static function mergeFilters(array ...$filters): array
+    {
+        return array_merge(...$filters);
+    }
+
+    /**
+     * Get the merged filter for one or more named scopes defined in getScopes().
+     *
+     * @param string ...$names
+     * @return array
+     */
+    public static function scope(string ...$names): array
+    {
+        $scopes = static::getScopes();
+        $result = [];
+        foreach ($names as $name) {
+            if (array_key_exists($name, $scopes)) {
+                $result = array_merge($result, $scopes[$name]);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * @return string
      * @throws MondocServiceMapErrorException
      */

--- a/src/Db/Service/Traits/Deletion/DeleteSingleTrait.php
+++ b/src/Db/Service/Traits/Deletion/DeleteSingleTrait.php
@@ -94,9 +94,14 @@ trait DeleteSingleTrait
      */
     public static function deleteModel(MondocAbstractModel $model): bool
     {
+        if ($model->beforeDelete() === false) {
+            return false;
+        }
+
         if (self::delete($model->getObjectId())) {
             $model->setMongoCollection(null);
             $model->unsetObjectId();
+            $model->afterDelete();
 
             return true;
         }

--- a/src/Db/Service/Traits/Persistence/InsertMultiTrait.php
+++ b/src/Db/Service/Traits/Persistence/InsertMultiTrait.php
@@ -95,6 +95,7 @@ trait InsertMultiTrait
         }
 
         $data = [];
+        $acceptedModels = [];
         foreach ($modelsForThisService as $model) {
             $hasModified = HasTraitHelper::has($model, MondocModifiedDateTrait::class);
             $hasCreated = HasTraitHelper::has($model, MondocCreatedDateTrait::class);
@@ -112,14 +113,19 @@ trait InsertMultiTrait
                 $model->incrementRevisionNumber();
             }
 
+            if ($model->beforeInsert() === false) {
+                continue;
+            }
+
             $asArray = $model->asArray(true);
             if ($model->hasPresetObjectId()) {
                 $asArray['_id'] = $model->getPresetObjectId();
             }
             $data[] = $asArray;
+            $acceptedModels[] = $model;
         }
 
-        if (!empty($modelsForThisService)) {
+        if (!empty($acceptedModels)) {
             $collection = self::getCollection(
                 get_called_class()
             );
@@ -131,11 +137,12 @@ trait InsertMultiTrait
                 $retentionModels = [];
                 $ids = $insert->getInsertedIds();
                 $insertedKey = 0;
-                foreach ($modelsForThisService as $v) {
+                foreach ($acceptedModels as $v) {
                     if (array_key_exists($insertedKey, $ids)) {
                         $v->setObjectId($ids[$insertedKey]);
                         $v->clearPresetObjectId();
                         $v->setMongoCollection($collection);
+                        $v->afterInsert();
                         if ($v->isMondocRetentionEnabled()) {
                             $retentionModels[] = MondocRetentionService::createStub($v);
                         }

--- a/src/Db/Service/Traits/Persistence/InsertSingleTrait.php
+++ b/src/Db/Service/Traits/Persistence/InsertSingleTrait.php
@@ -58,6 +58,10 @@ trait InsertSingleTrait
      */
     public static function insert(MondocAbstractModel $model, array $insertOptions = []): bool
     {
+        if ($model->beforeInsert() === false) {
+            return false;
+        }
+
         $collection = self::getCollection(
             get_called_class()
         );
@@ -82,6 +86,8 @@ trait InsertSingleTrait
             if ($model->isMondocRetentionEnabled()) {
                 MondocRetentionService::create($model);
             }
+
+            $model->afterInsert();
         }
 
         return $success;

--- a/src/Db/Service/Traits/Persistence/UpdateSingleTrait.php
+++ b/src/Db/Service/Traits/Persistence/UpdateSingleTrait.php
@@ -68,6 +68,9 @@ trait UpdateSingleTrait
         if (empty($model->getDirty())) {
             return true;
         }
+        if ($model->beforeUpdate() === false) {
+            return false;
+        }
         $data = $model->asArray(true);
         unset($data['_id']);
         $changeSet = [];
@@ -109,6 +112,8 @@ trait UpdateSingleTrait
             if ($model->isMondocRetentionEnabled()) {
                 MondocRetentionService::create($model);
             }
+
+            $model->afterUpdate();
 
             return true;
         }

--- a/tests/MondocTests/LifecycleHooksTest.php
+++ b/tests/MondocTests/LifecycleHooksTest.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests;
+
+use District5\Mondoc\Exception\MondocConfigConfigurationException;
+use District5\Mondoc\Exception\MondocException;
+use District5\Mondoc\Exception\MondocServiceMapErrorException;
+use District5Tests\MondocTests\TestObjects\Model\HookedModel;
+use District5Tests\MondocTests\TestObjects\Service\HookedService;
+
+/**
+ * Class LifecycleHooksTest.
+ *
+ * @package District5Tests\MondocTests
+ *
+ * @internal
+ */
+class LifecycleHooksTest extends MondocBaseTestAbstract
+{
+    /**
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     * @throws MondocException
+     */
+    public function testInsertHooksFire(): void
+    {
+        $m = new HookedModel();
+        $m->setName('Alice')->setAge(30);
+
+        $this->assertEquals(0, $m->getBeforeInsertCount());
+        $this->assertEquals(0, $m->getAfterInsertCount());
+
+        $this->assertTrue($m->save());
+
+        $this->assertEquals(1, $m->getBeforeInsertCount());
+        $this->assertEquals(1, $m->getAfterInsertCount());
+        $this->assertTrue($m->hasObjectId());
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     * @throws MondocException
+     */
+    public function testBeforeInsertVetoPreventsInsert(): void
+    {
+        $m = new HookedModel();
+        $m->setName('Bob')->setAge(25);
+        $m->setVetoInsert(true);
+
+        $this->assertFalse($m->save());
+        $this->assertEquals(1, $m->getBeforeInsertCount());
+        $this->assertEquals(0, $m->getAfterInsertCount());
+        $this->assertFalse($m->hasObjectId());
+        $this->assertEquals(0, HookedService::countAll());
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     * @throws MondocException
+     */
+    public function testUpdateHooksFire(): void
+    {
+        $m = new HookedModel();
+        $m->setName('Charlie')->setAge(20);
+        $this->assertTrue($m->save());
+
+        $m->setAge(21);
+
+        $this->assertEquals(0, $m->getBeforeUpdateCount());
+        $this->assertEquals(0, $m->getAfterUpdateCount());
+
+        $this->assertTrue($m->save());
+
+        $this->assertEquals(1, $m->getBeforeUpdateCount());
+        $this->assertEquals(1, $m->getAfterUpdateCount());
+
+        $retrieved = HookedService::getById($m->getObjectId());
+        $this->assertEquals(21, $retrieved->getAge());
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     * @throws MondocException
+     */
+    public function testBeforeUpdateVetoPreventsUpdate(): void
+    {
+        $m = new HookedModel();
+        $m->setName('Dave')->setAge(40);
+        $this->assertTrue($m->save());
+
+        $m->setAge(99);
+        $m->setVetoUpdate(true);
+
+        $this->assertFalse($m->save());
+        $this->assertEquals(1, $m->getBeforeUpdateCount());
+        $this->assertEquals(0, $m->getAfterUpdateCount());
+
+        $retrieved = HookedService::getById($m->getObjectId());
+        $this->assertEquals(40, $retrieved->getAge());
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     * @throws MondocException
+     */
+    public function testDeleteHooksFire(): void
+    {
+        $m = new HookedModel();
+        $m->setName('Eve')->setAge(28);
+        $this->assertTrue($m->save());
+
+        $id = $m->getObjectIdString();
+
+        $this->assertEquals(0, $m->getBeforeDeleteCount());
+        $this->assertEquals(0, $m->getAfterDeleteCount());
+
+        $this->assertTrue($m->delete());
+
+        $this->assertEquals(1, $m->getBeforeDeleteCount());
+        $this->assertEquals(1, $m->getAfterDeleteCount());
+        $this->assertFalse($m->hasObjectId());
+        $this->assertNull(HookedService::getById($id));
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     * @throws MondocException
+     */
+    public function testBeforeDeleteVetoPreventsDelete(): void
+    {
+        $m = new HookedModel();
+        $m->setName('Frank')->setAge(35);
+        $this->assertTrue($m->save());
+
+        $m->setVetoDelete(true);
+
+        $this->assertFalse($m->delete());
+        $this->assertEquals(1, $m->getBeforeDeleteCount());
+        $this->assertEquals(0, $m->getAfterDeleteCount());
+        $this->assertTrue($m->hasObjectId());
+        $this->assertEquals(1, HookedService::countAll());
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     * @throws MondocException
+     */
+    public function testInsertMultiHooksFire(): void
+    {
+        $a = new HookedModel();
+        $a->setName('Anna')->setAge(22);
+
+        $b = new HookedModel();
+        $b->setName('Ben')->setAge(19);
+
+        $this->assertTrue(HookedService::insertMulti([$a, $b]));
+
+        $this->assertEquals(1, $a->getBeforeInsertCount());
+        $this->assertEquals(1, $a->getAfterInsertCount());
+        $this->assertEquals(1, $b->getBeforeInsertCount());
+        $this->assertEquals(1, $b->getAfterInsertCount());
+        $this->assertTrue($a->hasObjectId());
+        $this->assertTrue($b->hasObjectId());
+        $this->assertEquals(2, HookedService::countAll());
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     * @throws MondocException
+     */
+    public function testInsertMultiVetoSkipsVetoedModel(): void
+    {
+        $a = new HookedModel();
+        $a->setName('Carol')->setAge(30);
+
+        $b = new HookedModel();
+        $b->setName('Dan')->setAge(25);
+        $b->setVetoInsert(true);
+
+        $this->assertTrue(HookedService::insertMulti([$a, $b]));
+
+        $this->assertEquals(1, $a->getBeforeInsertCount());
+        $this->assertEquals(1, $a->getAfterInsertCount());
+        $this->assertEquals(1, $b->getBeforeInsertCount());
+        $this->assertEquals(0, $b->getAfterInsertCount());
+        $this->assertTrue($a->hasObjectId());
+        $this->assertFalse($b->hasObjectId());
+        $this->assertEquals(1, HookedService::countAll());
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     */
+    public function testDefaultHooksReturnTrueAndDoNothing(): void
+    {
+        // Test that base MondocAbstractModel hook defaults work (no-op)
+        $m = new HookedModel();
+        $m->setVetoInsert(false);
+        $m->setVetoUpdate(false);
+        $m->setVetoDelete(false);
+
+        $this->assertTrue($m->beforeInsert());
+        $this->assertTrue($m->beforeUpdate());
+        $this->assertTrue($m->beforeDelete());
+        // afterInsert/Update/Delete return void — just confirm they don't throw
+        $m->afterInsert();
+        $m->afterUpdate();
+        $m->afterDelete();
+    }
+
+    /**
+     * @return void
+     * @throws MondocConfigConfigurationException
+     */
+    protected function setUp(): void
+    {
+        HookedService::deleteMulti([]);
+    }
+
+    /**
+     * @return void
+     * @throws MondocConfigConfigurationException
+     */
+    protected function tearDown(): void
+    {
+        HookedService::deleteMulti([]);
+    }
+}

--- a/tests/MondocTests/QueryScopesTest.php
+++ b/tests/MondocTests/QueryScopesTest.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests;
+
+use District5\Mondoc\Exception\MondocConfigConfigurationException;
+use District5\Mondoc\Exception\MondocException;
+use District5\Mondoc\Exception\MondocServiceMapErrorException;
+use District5Tests\MondocTests\TestObjects\Model\HookedModel;
+use District5Tests\MondocTests\TestObjects\Service\HookedService;
+use District5Tests\MondocTests\TestObjects\Service\MyService;
+
+/**
+ * Class QueryScopesTest.
+ *
+ * @package District5Tests\MondocTests
+ *
+ * @internal
+ */
+class QueryScopesTest extends MondocBaseTestAbstract
+{
+    /**
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     * @throws MondocException
+     */
+    public function testScopeFiltersCorrectly(): void
+    {
+        $alice = new HookedModel();
+        $alice->setName('Alice')->setAge(30);
+
+        $bob = new HookedModel();
+        $bob->setName('Bob')->setAge(15);
+
+        $charlie = new HookedModel();
+        $charlie->setName('Charlie')->setAge(45);
+
+        HookedService::insertMulti([$alice, $bob, $charlie]);
+
+        $adultsFilter = HookedService::scope('adults');
+        $this->assertArrayHasKey('age', $adultsFilter);
+        $this->assertEquals(['$gte' => 18], $adultsFilter['age']);
+
+        $adults = HookedService::getMultiByCriteria($adultsFilter);
+        $this->assertCount(2, $adults);
+
+        $aliceFilter = HookedService::scope('named_alice');
+        $aliceResults = HookedService::getMultiByCriteria($aliceFilter);
+        $this->assertCount(1, $aliceResults);
+        $this->assertEquals('Alice', $aliceResults[0]->getName());
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     * @throws MondocServiceMapErrorException
+     * @throws MondocException
+     */
+    public function testScopeWithMultipleNamesIsMerged(): void
+    {
+        $alice = new HookedModel();
+        $alice->setName('Alice')->setAge(30);
+
+        $bob = new HookedModel();
+        $bob->setName('Bob')->setAge(15);
+
+        HookedService::insertMulti([$alice, $bob]);
+
+        // Merging 'adults' and 'named_alice' — only Alice is both an adult and named Alice
+        $merged = HookedService::scope('adults', 'named_alice');
+        $this->assertArrayHasKey('age', $merged);
+        $this->assertArrayHasKey('name', $merged);
+
+        $results = HookedService::getMultiByCriteria($merged);
+        $this->assertCount(1, $results);
+        $this->assertEquals('Alice', $results[0]->getName());
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     */
+    public function testScopeWithUnknownNameReturnsEmptyFilter(): void
+    {
+        $filter = HookedService::scope('nonexistent_scope');
+        $this->assertIsArray($filter);
+        $this->assertEmpty($filter);
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     */
+    public function testMergeFiltersCombinesArrays(): void
+    {
+        $filter1 = ['age' => ['$gte' => 18]];
+        $filter2 = ['name' => 'Alice'];
+        $merged = HookedService::mergeFilters($filter1, $filter2);
+        $this->assertArrayHasKey('age', $merged);
+        $this->assertArrayHasKey('name', $merged);
+        $this->assertEquals(['$gte' => 18], $merged['age']);
+        $this->assertEquals('Alice', $merged['name']);
+    }
+
+    /**
+     * @throws MondocConfigConfigurationException
+     */
+    public function testServiceWithNoScopesReturnsEmptyArray(): void
+    {
+        // MyService does not define any scopes
+        $this->assertEmpty(MyService::scope('anything'));
+    }
+
+    /**
+     * @return void
+     * @throws MondocConfigConfigurationException
+     */
+    protected function setUp(): void
+    {
+        HookedService::deleteMulti([]);
+    }
+
+    /**
+     * @return void
+     * @throws MondocConfigConfigurationException
+     */
+    protected function tearDown(): void
+    {
+        HookedService::deleteMulti([]);
+    }
+}

--- a/tests/MondocTests/TestObjects/Model/HookedModel.php
+++ b/tests/MondocTests/TestObjects/Model/HookedModel.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests\TestObjects\Model;
+
+use District5\Mondoc\Db\Model\MondocAbstractModel;
+
+/**
+ * Class HookedModel
+ *
+ * @package District5Tests\MondocTests\TestObjects\Model
+ */
+class HookedModel extends MondocAbstractModel
+{
+    protected string $name = '';
+    protected int $age = 0;
+
+    // Private so they don't appear in asArray() serialisation
+    private bool $_vetoInsert = false;
+    private bool $_vetoUpdate = false;
+    private bool $_vetoDelete = false;
+
+    private int $_beforeInsertCount = 0;
+    private int $_afterInsertCount = 0;
+    private int $_beforeUpdateCount = 0;
+    private int $_afterUpdateCount = 0;
+    private int $_beforeDeleteCount = 0;
+    private int $_afterDeleteCount = 0;
+
+    public function setVetoInsert(bool $v): void { $this->_vetoInsert = $v; }
+    public function setVetoUpdate(bool $v): void { $this->_vetoUpdate = $v; }
+    public function setVetoDelete(bool $v): void { $this->_vetoDelete = $v; }
+
+    public function getBeforeInsertCount(): int { return $this->_beforeInsertCount; }
+    public function getAfterInsertCount(): int { return $this->_afterInsertCount; }
+    public function getBeforeUpdateCount(): int { return $this->_beforeUpdateCount; }
+    public function getAfterUpdateCount(): int { return $this->_afterUpdateCount; }
+    public function getBeforeDeleteCount(): int { return $this->_beforeDeleteCount; }
+    public function getAfterDeleteCount(): int { return $this->_afterDeleteCount; }
+
+    public function beforeInsert(): bool
+    {
+        $this->_beforeInsertCount++;
+        return !$this->_vetoInsert;
+    }
+
+    public function afterInsert(): void
+    {
+        $this->_afterInsertCount++;
+    }
+
+    public function beforeUpdate(): bool
+    {
+        $this->_beforeUpdateCount++;
+        return !$this->_vetoUpdate;
+    }
+
+    public function afterUpdate(): void
+    {
+        $this->_afterUpdateCount++;
+    }
+
+    public function beforeDelete(): bool
+    {
+        $this->_beforeDeleteCount++;
+        return !$this->_vetoDelete;
+    }
+
+    public function afterDelete(): void
+    {
+        $this->_afterDeleteCount++;
+    }
+
+    public function getName(): string { return $this->name; }
+    public function setName(string $name): static { $this->name = $name; return $this; }
+    public function getAge(): int { return $this->age; }
+    public function setAge(int $age): static { $this->age = $age; return $this; }
+
+    protected function assignDefaultVars(): void
+    {
+    }
+}

--- a/tests/MondocTests/TestObjects/Service/HookedService.php
+++ b/tests/MondocTests/TestObjects/Service/HookedService.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * District5 Mondoc Library
+ *
+ * @author      District5 <hello@district5.co.uk>
+ * @copyright   District5 <hello@district5.co.uk>
+ * @link        https://www.district5.co.uk
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace District5Tests\MondocTests\TestObjects\Service;
+
+/**
+ * Class HookedService.
+ *
+ * @package District5Tests\MondocTests\TestObjects\Service
+ */
+class HookedService extends AbstractTestService
+{
+    protected static function getScopes(): array
+    {
+        return [
+            'adults'     => ['age' => ['$gte' => 18]],
+            'named_alice' => ['name' => 'Alice'],
+        ];
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,11 +17,13 @@ use District5Tests\MondocTests\TestObjects\Model\TopLevelRetainedTestModel;
 use District5Tests\MondocTests\TestObjects\Model\SingleAndMultiNestedModel;
 use District5Tests\MondocTests\TestObjects\Model\HelperTraitsModel;
 use District5Tests\MondocTests\TestObjects\Model\HelperTraitsOtherModel;
+use District5Tests\MondocTests\TestObjects\Model\HookedModel;
 use District5Tests\MondocTests\TestObjects\ModelChanges\FooModel;
 use District5Tests\MondocTests\TestObjects\ModelChanges\FooService;
 use District5Tests\MondocTests\TestObjects\ModelChanges\FooWithMoreFieldsModel;
 use District5Tests\MondocTests\TestObjects\ModelChanges\FooWithMoreFieldsService;
 use District5Tests\MondocTests\TestObjects\Service\AllTypesService;
+use District5Tests\MondocTests\TestObjects\Service\HookedService;
 use District5Tests\MondocTests\TestObjects\Service\DateService;
 use District5Tests\MondocTests\TestObjects\Service\FieldAliasTestService;
 use District5Tests\MondocTests\TestObjects\Service\FinancialCandleService;
@@ -88,6 +90,9 @@ $mondoc->addServiceMapping(
 )->addServiceMapping(
     FooWithMoreFieldsModel::class,
     FooWithMoreFieldsService::class
+)->addServiceMapping(
+    HookedModel::class,
+    HookedService::class
 ); // just to cover the addServiceMapping method
 
 function cleanupCollections($mondoc): void


### PR DESCRIPTION
### Hooks and scopes

Introduces hooks for pre and post insertion/update/deletion requests.

Scopes for querying, at the service level...

```
class MyService extends MondocAbstractService
{
    protected static function getScopes(): array
    {
        return [
            'adults'     => ['age' => ['$gte' => 18]],
            'named_alice' => ['name' => 'Alice'],
        ];
    }
}

$aliceResults = MyService::getMultiByCriteria(
    MyService::scope('named_alice')
);
```


**Flags**

- [ ] This is a breaking change.
- [x] This is a new feature.
- [ ] This is a bug fix.

**Requirements**

- [x] This is a pull request.
- [x] My code is tested.
- [x] The tests for my changes are included in this PR.
- [x] The code style is respected and followed.
